### PR TITLE
Fix the StateDefinition's Transition property

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With the SDK, you can:
 
 | Latest Releases | Conformance to spec version |
 | :---: | :---: |
-| [0.6.0](https://github.com/serverlessworkflow/sdk-net/releases/) | [v0.6](https://github.com/serverlessworkflow/specification/tree/0.6.x) |
+| [0.6.1](https://github.com/serverlessworkflow/sdk-net/releases/) | [v0.6](https://github.com/serverlessworkflow/specification/tree/0.6.x) |
 
 ### Getting Started
 

--- a/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
@@ -159,9 +159,9 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the <see cref="JToken"/> that represents the <see cref="StateDefinition"/>'s <see cref="EndDefinition"/>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = nameof(End))]
-        [System.Text.Json.Serialization.JsonPropertyName(nameof(End))]
-        [YamlMember(Alias = nameof(End))]
+        [Newtonsoft.Json.JsonProperty(PropertyName = nameof(DataInputSchema))]
+        [System.Text.Json.Serialization.JsonPropertyName(nameof(DataInputSchema))]
+        [YamlMember(Alias = nameof(DataInputSchema))]
         protected virtual JToken DataInputSchemaToken { get; set; }
 
         private DataInputSchemaDefinition _DataInputSchema;

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
@@ -21,7 +21,7 @@
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup>
     <DocumentationFile>ServerlessWorkflow.Sdk.xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
-    <AssemblyVersion>0.6.0.0</AssemblyVersion>
-    <FileVersion>0.6.0.0</FileVersion>
-    <Version>0.6.0</Version>
+    <AssemblyVersion>0.6.1.0</AssemblyVersion>
+    <FileVersion>0.6.1.0</FileVersion>
+    <Version>0.6.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -175,6 +175,21 @@
             Gets/sets an expression evaluated against state data. True if results are not empty
             </summary>
         </member>
+        <member name="T:ServerlessWorkflow.Sdk.Models.DataInputSchemaDefinition">
+            <summary>
+            Represents the object used to configure a <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s data input schema
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.DataInputSchemaDefinition.Schema">
+            <summary>
+            Gets/sets the url of the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s input data schema
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.DataInputSchemaDefinition.FailOnValidationError">
+            <summary>
+            Gets/sets a boolean indicating whether or not to terminate the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s execution whenever the validation of the input data fails. Defaults to true.
+            </summary>
+        </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.DefaultDefinition">
             <summary>
             Represents an object used to define the transition of the workflow if there is no matching data conditions or event timeout is reached
@@ -799,6 +814,16 @@
         <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.Transition">
             <summary>
             Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/>
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.DataInputSchemaToken">
+            <summary>
+            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/>
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.DataInputSchema">
+            <summary>
+            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.DataInputSchemaDefinition"/>
             </summary>
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.CompensatedBy">
@@ -3894,6 +3919,16 @@
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.Serialization.YamlDotNetSerializer.SerializeAsync(System.Object,System.Type,System.Threading.CancellationToken)">
             <inheritdoc/>
+        </member>
+        <member name="T:ServerlessWorkflow.Sdk.Services.Validation.WorkflowValidator">
+            <summary>
+            Represents the service used to validate <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>s
+            </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.WorkflowValidator.#ctor">
+            <summary>
+            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Services.Validation.WorkflowValidator"/>
+            </summary>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.StateType">
             <summary>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes the StateDefinition's Transition property, which is marked with attributes referencing the 'End' property, resulting in serialization exceptions.