### PR TITLE
Fix the ODataQueryOptions 'Top' and 'Skip' properties

### DIFF
--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/WorkflowValidationTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/WorkflowValidationTests.cs
@@ -243,7 +243,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
 
             //assert
             result.Should()
-               .NotBeNull();
+                .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
                 .And.Contain(e => e.PropertyName == nameof(WorkflowDefinition.States));

--- a/src/ServerlessWorkflow.Sdk/Models/ODataQueryOptions.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ODataQueryOptions.cs
@@ -47,12 +47,12 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets the $top system query option, which allows clients a required number of resources. Usually used in conjunction with the $skip query options
         /// </summary>
-        public virtual int Top { get; set; }
+        public virtual int? Top { get; set; }
 
         /// <summary>
         /// Gets the $skip system query option, which allows clients to skip a given number of resources. Usually used in conjunction with the $top query options
         /// </summary>
-        public virtual int Skip { get; set; }
+        public virtual int? Skip { get; set; }
 
         /// <summary>
         /// Gets the $count system query option, which allows clients to request a count of the matching resources included with the resources in the response

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
-    <AssemblyVersion>0.7.4.2</AssemblyVersion>
-    <FileVersion>0.7.4.2</FileVersion>
-    <Version>0.7.4.2</Version>
+    <AssemblyVersion>0.7.4.3</AssemblyVersion>
+    <FileVersion>0.7.4.3</FileVersion>
+    <Version>0.7.4.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -830,7 +830,7 @@
             Represents the options used to configure an OData command
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.ODataCommandOptions.Id">
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataCommandOptions.Key">
             <summary>
             Gets the unique identifier of the single entry to query
             </summary>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fix the ODataQueryOptions by turning the 'Top' and 'Skip' properties into nullables