### PR TITLE
NET6 + ProtoBuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Serverless Workflow Specification - .NET SDK
 
-Provides .NET 5.0 API/SPI and Model Validation for the [Serverless Workflow Specification](https://github.com/serverlessworkflow/specification)
+Provides .NET 6.0 API/SPI and Model Validation for the [Serverless Workflow Specification](https://github.com/serverlessworkflow/specification)
 
 With the SDK, you can:
 
@@ -46,10 +46,15 @@ var workflow = WorkflowDefinition.Create("MyWorkflow", "MyWorkflow", "1.0")
       })      
           .Execute("fakeEventTrigger", action =>
           {
-              action.Consume(e =>
-                  e.WithName("fakeEvent")
-                      .WithSource(new Uri("https://fakesource.com"))
-                      .WithType("fakeType"));
+               action
+                    .Consume(e =>
+                        e.WithName("fakeEvent")
+                            .WithSource(new Uri("https://fakesource.com"))
+                            .WithType("fakeType"))
+                    .ThenProduce(e =>
+                        e.WithName("otherEvent")
+                            .WithSource(new Uri("https://fakesource.com"))
+                            .WithType("fakeType"));
           }))
   .End()
   .Build();

--- a/ServerlessWorkflow.Sdk.sln
+++ b/ServerlessWorkflow.Sdk.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31019.35
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerlessWorkflow.Sdk", "ServerlessWorkflow.Sdk\ServerlessWorkflow.Sdk.csproj", "{E174F5CC-F3DC-4370-AAC1-AC1D7724C792}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerlessWorkflow.Sdk", "src\ServerlessWorkflow.Sdk\ServerlessWorkflow.Sdk.csproj", "{E174F5CC-F3DC-4370-AAC1-AC1D7724C792}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerlessWorkflow.Sdk.UnitTests", "ServerlessWorkflow.Sdk.UnitTests\ServerlessWorkflow.Sdk.UnitTests.csproj", "{70AD35E0-0C14-4EBF-A841-B0D084392753}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerlessWorkflow.Sdk.UnitTests", "src\ServerlessWorkflow.Sdk.UnitTests\ServerlessWorkflow.Sdk.UnitTests.csproj", "{70AD35E0-0C14-4EBF-A841-B0D084392753}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Services/WorkflowReaderTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Services/WorkflowReaderTests.cs
@@ -61,6 +61,13 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Services
             workflow.States
                 .Should()
                 .NotBeEmpty();
+            workflow.Metadata
+                .Should()
+                .NotBeNull();
+            workflow.Metadata
+                .Get("podSize")
+                .Should()
+                .Be("small");
         }
 
         [Fact]
@@ -96,7 +103,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Services
                 .NotBeNull();
             workflow.Constants
                 .Should()
-                .NotBeEmpty();
+                .NotBeNull();
             workflow.Secrets
                 .Should()
                 .NotBeEmpty();

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Services/WorkflowReaderTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Services/WorkflowReaderTests.cs
@@ -39,7 +39,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Services
 
         protected IWorkflowReader Reader { get; } = WorkflowReader.Create();
 
-        [Fact(Skip = "Does not work on GIT")]
+        [Fact]
         public async Task Read_LocalExamples()
         {
             //arrange
@@ -81,7 +81,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Services
             }
         }
 
-        [Fact(Skip = "Does not work on GIT")]
+        [Fact]
         public async Task Read_ExternalDefinitions()
         {
             //arrange

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Services/WorkflowReaderTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Services/WorkflowReaderTests.cs
@@ -40,38 +40,69 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Services
         protected IWorkflowReader Reader { get; } = WorkflowReader.Create();
 
         [Fact]
-        public async Task Read_LocalExamples()
+        public async Task Read_Yaml_ShouldWork()
         {
             //arrange
             var yaml = File.ReadAllText(Path.Combine("Resources", "Workflows", "operation.yaml"));
 
             //act
-            var workflow = await this.Reader.ParseAsync(yaml);
+            var parsedWorkflow = await this.Reader.ParseAsync(yaml);
 
             //assert
-            workflow
+            parsedWorkflow
                 .Should()
                 .NotBeNull();
-            workflow.Events
+            parsedWorkflow.Events
                 .Should()
                 .NotBeEmpty();
-            workflow.Functions
+            parsedWorkflow.Functions
                 .Should()
                 .NotBeEmpty();
-            workflow.States
+            parsedWorkflow.States
                 .Should()
                 .NotBeEmpty();
-            workflow.Metadata
+            parsedWorkflow.Metadata
                 .Should()
                 .NotBeNull();
-            workflow.Metadata
+            parsedWorkflow.Metadata
                 .Get("podSize")
                 .Should()
                 .Be("small");
         }
 
         [Fact]
-        public async Task Read_OfficialExamples()
+        public async Task Read_Json_ShouldWork()
+        {
+            //arrange
+            var yaml = File.ReadAllText(Path.Combine("Resources", "Workflows", "operation.json"));
+
+            //act
+            var parsedWorkflow = await this.Reader.ParseAsync(yaml);
+
+            //assert
+            parsedWorkflow
+                .Should()
+                .NotBeNull();
+            parsedWorkflow.Events
+                .Should()
+                .NotBeEmpty();
+            parsedWorkflow.Functions
+                .Should()
+                .NotBeEmpty();
+            parsedWorkflow.States
+                .Should()
+                .NotBeEmpty();
+            parsedWorkflow.Metadata
+                .Should()
+                .NotBeNull();
+            parsedWorkflow.Metadata
+                .Get("podSize")
+                .Should()
+                .Be("small");
+        }
+
+        [Fact]
+        public async Task Read_OfficialExamples_ShouldWork()
         {
             IDictionary<string, string> errors = new Dictionary<string, string>();
             await foreach(Example example in GetOfficialExamplesAsync())
@@ -89,7 +120,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Services
         }
 
         [Fact]
-        public async Task Read_ExternalDefinitions()
+        public async Task Read_ExternalDefinitions_ShouldWork()
         {
             //arrange
             var yaml = File.ReadAllText(Path.Combine("Resources", "Workflows", "externalref.yaml"));

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Services/WorkflowWriterTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Services/WorkflowWriterTests.cs
@@ -50,14 +50,15 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Services
                     })
                         .Execute("fakeEventTrigger", action =>
                         {
-                            action.Consume(e =>
-                                e.WithName("fakeEvent")
-                                    .WithSource(new Uri("https://fakesource.com"))
-                                    .WithType("fakeType"))
-                                  .ThenProduce(e =>
-                                e.WithName("otherEvent")
-                                    .WithSource(new Uri("https://fakesource.com"))
-                                    .WithType("fakeType"));
+                            action
+                                .Consume(e =>
+                                    e.WithName("fakeEvent")
+                                        .WithSource(new Uri("https://fakesource.com"))
+                                        .WithType("fakeType"))
+                                .ThenProduce(e =>
+                                    e.WithName("otherEvent")
+                                        .WithSource(new Uri("https://fakesource.com"))
+                                        .WithType("fakeType"));
                         }))
                 .End()
                 .Build();

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/CallbackStateValidationTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/CallbackStateValidationTests.cs
@@ -40,7 +40,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
                 .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
-                .And.Contain(e => e.ErrorCode == "States[0]" && e.ErrorMessage.StartsWith($"{nameof(CallbackStateDefinition)}.{nameof(CallbackStateDefinition.Action)}"));
+                .And.Contain(e => e.ErrorCode.StartsWith($"{nameof(CallbackStateDefinition)}.{nameof(CallbackStateDefinition.Action)}"));
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
                 .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
-                .And.Contain(e => e.ErrorCode == "States[0]" && e.ErrorMessage.Contains($"{nameof(CallbackStateDefinition)}.{nameof(CallbackStateDefinition.Event)}"));
+                .And.Contain(e => e.ErrorCode.Contains($"{nameof(CallbackStateDefinition)}.{nameof(CallbackStateDefinition.Event)}"));
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
                 .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
-                .And.Contain(e => e.ErrorCode == "States[0]" && e.ErrorMessage.Contains($"{nameof(CallbackStateDefinition)}.{nameof(CallbackStateDefinition.Event)}"));
+                .And.Contain(e => e.ErrorCode.Contains($"{nameof(CallbackStateDefinition)}.{nameof(CallbackStateDefinition.Event)}"));
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/EventStateValidationTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/EventStateValidationTests.cs
@@ -40,7 +40,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
                 .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
-                .And.Contain(e => e.ErrorCode == "States[0]" && e.ErrorMessage.StartsWith($"{nameof(EventStateDefinition)}.{nameof(EventStateDefinition.Triggers)}"));
+                .And.Contain(e => e.ErrorCode.StartsWith($"{nameof(EventStateDefinition)}.{nameof(EventStateDefinition.Triggers)}"));
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/InjectStateValidationTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/InjectStateValidationTests.cs
@@ -39,7 +39,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
                 .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
-                .And.Contain(e => e.ErrorCode == "States[0]" && e.ErrorMessage.StartsWith($"{nameof(InjectStateDefinition)}.{nameof(InjectStateDefinition.Data)}"));
+                .And.Contain(e => e.ErrorCode.StartsWith($"{nameof(InjectStateDefinition)}.{nameof(InjectStateDefinition.Data)}"));
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/SwitchStateValidationTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/SwitchStateValidationTests.cs
@@ -39,8 +39,8 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
                 .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
-                .And.Contain(e => e.ErrorCode == "States[0]" && e.ErrorMessage.Contains($"{nameof(SwitchStateDefinition)}.{nameof(SwitchStateDefinition.DataConditions)}"))
-                .And.Contain(e => e.ErrorCode == "States[0]" && e.ErrorMessage.Contains($"{nameof(SwitchStateDefinition)}.{nameof(SwitchStateDefinition.EventConditions)}"));
+                .And.Contain(e => e.ErrorCode.Contains($"{nameof(SwitchStateDefinition)}.{nameof(SwitchStateDefinition.DataConditions)}"))
+                .And.Contain(e => e.ErrorCode.Contains($"{nameof(SwitchStateDefinition)}.{nameof(SwitchStateDefinition.EventConditions)}"));
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
                 .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
-                .And.Contain(e => e.ErrorCode == "States[0]" && e.ErrorMessage.Contains($"{nameof(SwitchStateDefinition)}.{nameof(SwitchStateDefinition.DefaultCondition)}"));
+                .And.Contain(e => e.ErrorCode.Contains($"{nameof(SwitchStateDefinition)}.{nameof(SwitchStateDefinition.DefaultCondition)}"));
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/WorkflowValidationTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/WorkflowValidationTests.cs
@@ -197,7 +197,9 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
                 Id = "fake",
                 Name = "fake",
                 Version = "fake",
-                Events = new() { new() { Name = "fake", Source = "fake", Type = "fake" }, new() { Name = "fake", Source = "fake", Type = "fake" } }
+                Events = new() { new() { Name = "fake", Source = "fake", Type = "fake" }, new() { Name = "fake", Source = "fake", Type = "fake" } },
+                Start = "sleep",
+                States = new() { new SleepStateDefinition() {Name = "sleep", Delay = TimeSpan.FromSeconds(2), End = true } }
             };
 
             //act

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/WorkflowValidationTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/WorkflowValidationTests.cs
@@ -243,7 +243,7 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
 
             //assert
             result.Should()
-               .NotBeNull();
+                .NotBeNull();
             result.Errors.Should()
                 .NotBeNullOrEmpty()
                 .And.Contain(e => e.PropertyName == nameof(WorkflowDefinition.States));

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/WorkflowValidationTests.cs
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Cases/Validation/WorkflowValidationTests.cs
@@ -146,11 +146,13 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
         public void Validate_Workflow_NoEnd_ShouldFail()
         {
             //arrange
-            var workflow = new WorkflowDefinition();
-            workflow.Id = "fake";
-            workflow.Name = "fake";
-            workflow.Version = "fake";
-            workflow.States = new() { new InjectStateDefinition() { Name = "fake" } };
+            var workflow = new WorkflowDefinition
+            {
+                Id = "fake",
+                Name = "fake",
+                Version = "fake",
+                States = new() { new InjectStateDefinition() { Name = "fake" } }
+            };
 
             //act
             var result = this.WorkflowDefinitionValidator.Validate(workflow);
@@ -190,11 +192,13 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
         public void Validate_Workflow_DuplicateEventNames_ShouldFail()
         {
             //arrange
-            var workflow = new WorkflowDefinition();
-            workflow.Id = "fake";
-            workflow.Name = "fake";
-            workflow.Version = "fake";
-            workflow.Events = new() { new() { Name = "fake", Source = "fake", Type = "fake" }, new() { Name = "fake", Source = "fake", Type = "fake" } };
+            var workflow = new WorkflowDefinition
+            {
+                Id = "fake",
+                Name = "fake",
+                Version = "fake",
+                Events = new() { new() { Name = "fake", Source = "fake", Type = "fake" }, new() { Name = "fake", Source = "fake", Type = "fake" } }
+            };
 
             //act
             var result = this.WorkflowDefinitionValidator.Validate(workflow);
@@ -211,11 +215,13 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
         public void Validate_Workflow_DuplicateFunctionNames_ShouldFail()
         {
             //arrange
-            var workflow = new WorkflowDefinition();
-            workflow.Id = "fake";
-            workflow.Name = "fake";
-            workflow.Version = "fake";
-            workflow.Functions = new() { new() { Name = "fake", Operation = "fake" }, new() { Name = "fake", Operation = "fake" } };
+            var workflow = new WorkflowDefinition
+            {
+                Id = "fake",
+                Name = "fake",
+                Version = "fake",
+                Functions = new() { new() { Name = "fake", Operation = "fake" }, new() { Name = "fake", Operation = "fake" } }
+            };
 
             //act
             var result = this.WorkflowDefinitionValidator.Validate(workflow);
@@ -232,11 +238,13 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
         public void Validate_Workflow_DuplicateStateNames_ShouldFail()
         {
             //arrange
-            var workflow = new WorkflowDefinition();
-            workflow.Id = "fake";
-            workflow.Name = "fake";
-            workflow.Version = "fake";
-            workflow.States = new() { new InjectStateDefinition() { Name = "fake" }, new InjectStateDefinition() { Name = "fake" } };
+            var workflow = new WorkflowDefinition
+            {
+                Id = "fake",
+                Name = "fake",
+                Version = "fake",
+                States = new() { new InjectStateDefinition() { Name = "fake" }, new InjectStateDefinition() { Name = "fake" } }
+            };
 
             //act
             var result = this.WorkflowDefinitionValidator.Validate(workflow);
@@ -253,11 +261,13 @@ namespace ServerlessWorkflow.Sdk.UnitTests.Cases.Validation
         public void Validate_Workflow_DuplicateRetryPolicyNames_ShouldFail()
         {
             //arrange
-            var workflow = new WorkflowDefinition();
-            workflow.Id = "fake";
-            workflow.Name = "fake";
-            workflow.Version = "fake";
-            workflow.Retries = new() { new () { Name = "fake" }, new () { Name = "fake" } };
+            var workflow = new WorkflowDefinition
+            {
+                Id = "fake",
+                Name = "fake",
+                Version = "fake",
+                Retries = new() { new() { Name = "fake" }, new() { Name = "fake" } }
+            };
 
             //act
             var result = this.WorkflowDefinitionValidator.Validate(workflow);

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Resources/workflows/operation.json
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Resources/workflows/operation.json
@@ -1,0 +1,54 @@
+﻿{
+  "id": "operation",
+  "name": "Operation",
+  "version": "0.1.0",
+  "events": [
+    {
+      "name": "ProducedEvent",
+      "kind": "produced",
+      "type": "producedEvent",
+      "source": "workflow"
+    },
+    {
+      "name": "ConsumedEvent",
+      "kind": "consumed",
+      "type": "consumedEvent",
+      "source": "workflow"
+    }
+  ],
+  "functions": [
+    {
+      "name": "Function",
+      "operation": "http://fake.address"
+    }
+  ],
+  "metadata": {
+    "podSize": "small"
+  },
+  "start": "Operation",
+  "states": [
+    {
+      "name": "Operation",
+      "type": "operation",
+      "actions": [
+        {
+          "name": "Function",
+          "functionRef": {
+            "refName": "Function",
+            "arguments": {
+              "message": "Hello world!"
+            }
+          }
+        },
+        {
+          "name": "Function",
+          "eventRef": {
+            "triggerEventRef": "ProducedEvent",
+            "resultEventRef": "ConsumedEvent"
+          }
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Resources/workflows/operation.yaml
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Resources/workflows/operation.yaml
@@ -13,6 +13,7 @@ events:
 functions:
   - name: Function
     operation: http://fake.address
+start: Operation
 states:
   - name: Operation
     type: operation

--- a/src/ServerlessWorkflow.Sdk.UnitTests/Resources/workflows/operation.yaml
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/Resources/workflows/operation.yaml
@@ -13,6 +13,8 @@ events:
 functions:
   - name: Function
     operation: http://fake.address
+metadata:
+  podSize: small
 start: Operation
 states:
   - name: Operation

--- a/src/ServerlessWorkflow.Sdk.UnitTests/ServerlessWorkflow.Sdk.UnitTests.csproj
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/ServerlessWorkflow.Sdk.UnitTests.csproj
@@ -41,6 +41,9 @@
     <None Update="Resources\secrets\default.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\workflows\operation.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\workflows\operation.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/ServerlessWorkflow.Sdk.UnitTests/ServerlessWorkflow.Sdk.UnitTests.csproj
+++ b/src/ServerlessWorkflow.Sdk.UnitTests/ServerlessWorkflow.Sdk.UnitTests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/ServerlessWorkflow.Sdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/ServerlessWorkflow.Sdk/Extensions/IServiceCollectionExtensions.cs
@@ -160,6 +160,7 @@ namespace ServerlessWorkflow.Sdk
                     .WithTypeConverter(new Iso8601TimeSpanSerializer())
                     .WithTypeConverter(new StringEnumSerializer())
                     .WithTypeConverter(new OneOfConverter())
+                    .WithTypeConverter(new AnyConverter())
                     .WithEmissionPhaseObjectGraphVisitor(args => new ChainedObjectGraphVisitor(args.InnerVisitor)),
                 deserializer => deserializer
                     .WithNodeDeserializer(
@@ -167,7 +168,10 @@ namespace ServerlessWorkflow.Sdk
                         syntax => syntax.InsteadOf<ScalarNodeDeserializer>())
                     .WithNodeDeserializer(
                         inner => new OneOfDeserializer(inner),
-                        syntax => syntax.InsteadOf<Iso8601TimeSpanConverter>()));
+                        syntax => syntax.InsteadOf<Iso8601TimeSpanConverter>())
+                    .WithNodeDeserializer(
+                        inner => new AnyDeserializer(inner),
+                        syntax => syntax.InsteadOf<OneOfDeserializer>()));
             services.AddHttpClient();
             services.AddSingleton<IWorkflowReader, WorkflowReader>();
             services.AddSingleton<IWorkflowWriter, WorkflowWriter>();

--- a/src/ServerlessWorkflow.Sdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/ServerlessWorkflow.Sdk/Extensions/IServiceCollectionExtensions.cs
@@ -15,7 +15,6 @@
  *
  */
 using FluentValidation;
-using FluentValidation.AspNetCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Newtonsoft.Json;
@@ -88,17 +87,10 @@ namespace ServerlessWorkflow.Sdk
         /// <returns>The configured <see cref="IServiceCollection"/></returns>
         public static IServiceCollection AddYamlDotNet(this IServiceCollection services, Action<SerializerBuilder> serializerConfiguration = null, Action<DeserializerBuilder> deserializerConfiguration = null)
         {
-            services.TryAddSingleton(provider =>
-            {
-                SerializerBuilder builder = new SerializerBuilder()
-                    .WithNamingConvention(CamelCaseNamingConvention.Instance);
-                serializerConfiguration?.Invoke(builder);
-                return builder.Build();
-            });
-            services.TryAddSingleton(provider =>
-            {
-                DeserializerBuilder builder = new DeserializerBuilder()
-                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            Action<SerializerBuilder> defaultSerializerConfiguration = builder => 
+                builder.WithNamingConvention(CamelCaseNamingConvention.Instance);
+            Action<DeserializerBuilder> defaultDeserializerConfiguration = builder =>
+                builder.WithNamingConvention(CamelCaseNamingConvention.Instance)
                     .WithNodeDeserializer(
                         inner => new JArrayDeserializer(inner),
                         syntax => syntax.InsteadOf<ArrayNodeDeserializer>())
@@ -110,6 +102,27 @@ namespace ServerlessWorkflow.Sdk
                         syntax => syntax.InsteadOf<DictionaryNodeDeserializer>())
                     .WithObjectFactory(new NonPublicConstructorObjectFactory())
                     .IncludeNonPublicProperties();
+            Yaml.SerializerConfiguration = builder =>
+            {
+                defaultSerializerConfiguration(builder);
+                serializerConfiguration?.Invoke(builder);
+            };
+            Yaml.DeserializerConfiguration = builder =>
+            {
+                defaultDeserializerConfiguration(builder);
+                deserializerConfiguration?.Invoke(builder);
+            };
+            services.TryAddSingleton(provider =>
+            {
+                SerializerBuilder builder = new SerializerBuilder();
+                defaultSerializerConfiguration(builder);
+                serializerConfiguration?.Invoke(builder);
+                return builder.Build();
+            });
+            services.TryAddSingleton(provider =>
+            {
+                DeserializerBuilder builder = new DeserializerBuilder();
+                defaultDeserializerConfiguration(builder);
                 deserializerConfiguration?.Invoke(builder);
                 return builder.Build();
             });
@@ -146,11 +159,15 @@ namespace ServerlessWorkflow.Sdk
                     .WithTypeConverter(new JTokenSerializer())
                     .WithTypeConverter(new Iso8601TimeSpanSerializer())
                     .WithTypeConverter(new StringEnumSerializer())
+                    .WithTypeConverter(new OneOfConverter())
                     .WithEmissionPhaseObjectGraphVisitor(args => new ChainedObjectGraphVisitor(args.InnerVisitor)),
                 deserializer => deserializer
                     .WithNodeDeserializer(
                         inner => new Iso8601TimeSpanConverter(inner),
-                        syntax => syntax.InsteadOf<ScalarNodeDeserializer>()));
+                        syntax => syntax.InsteadOf<ScalarNodeDeserializer>())
+                    .WithNodeDeserializer(
+                        inner => new OneOfDeserializer(inner),
+                        syntax => syntax.InsteadOf<Iso8601TimeSpanConverter>()));
             services.AddHttpClient();
             services.AddSingleton<IWorkflowReader, WorkflowReader>();
             services.AddSingleton<IWorkflowWriter, WorkflowWriter>();

--- a/src/ServerlessWorkflow.Sdk/IOneOf.cs
+++ b/src/ServerlessWorkflow.Sdk/IOneOf.cs
@@ -1,0 +1,18 @@
+﻿namespace ServerlessWorkflow.Sdk
+{
+
+    /// <summary>
+    /// Defines the fundamentals of a service that wraps around multiple alternative value types
+    /// </summary>
+    public interface IOneOf
+    {
+
+        /// <summary>
+        /// Gets the object's current value
+        /// </summary>
+        /// <returns>The object's current value</returns>
+        object GetValue();
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Models/ActionDataFilterDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ActionDataFilterDefinition.cs
@@ -14,28 +14,37 @@
  * limitations under the License.
  *
  */
+
 namespace ServerlessWorkflow.Sdk.Models
 {
 
     /// <summary>
     /// Represents the object used to configure how actions filter the state data for both input and output
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ActionDataFilterDefinition
     {
 
         /// <summary>
         /// Gets/sets an expression that filters state data that can be used by the action
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string FromStateData { get; set; }
 
         /// <summary>
         /// Gets/sets an expression that filters the actions data results
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Results { get; set; }
 
         /// <summary>
         /// Gets/sets an expression that selects a state data element to which the action results should be added/merged into. If not specified denotes the top-level state data element
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual string ToStateData { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ActionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ActionDefinition.cs
@@ -86,10 +86,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Function == null
                     && this.FunctionToken != null)
                 {
-                    if (this.FunctionToken.Value1 == null)
-                        this._Function = new FunctionReference() { RefName = this.FunctionToken.Value2 };
+                    if (this.FunctionToken.T1Value == null)
+                        this._Function = new FunctionReference() { RefName = this.FunctionToken.T2Value };
                     else
-                        this._Function = this.FunctionToken.Value1;
+                        this._Function = this.FunctionToken.T1Value;
                 }
                   
                 return this._Function;
@@ -142,20 +142,20 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Subflow == null
                     && this.SubflowToken != null)
                 {
-                    if (this.SubflowToken.Value1 == null)
+                    if (this.SubflowToken.T1Value == null)
                     {
-                        var components = this.SubflowToken.Value2.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                        var components = this.SubflowToken.T2Value.Split(':', StringSplitOptions.RemoveEmptyEntries);
                         var id = components.First();
                         var version = (string)null;
                         if(components.Length > 1)
                         {
                             version = components.Last();
-                            id = this.SubflowToken.Value2[..^(version.Length + 1)];
+                            id = this.SubflowToken.T2Value[..^(version.Length + 1)];
                         }
                         this._Subflow = new() { WorkflowId = id, Version = version };
                     }
                     else
-                        this._Subflow = this.SubflowToken.Value1;
+                        this._Subflow = this.SubflowToken.T1Value;
                 }
                 return this._Subflow;
             }

--- a/src/ServerlessWorkflow.Sdk/Models/Any.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Any.cs
@@ -14,46 +14,47 @@
  * limitations under the License.
  *
  */
-using Newtonsoft.Json.Linq;
-using System.ComponentModel.DataAnnotations;
+using Neuroglia.Serialization;
+using System.Collections.Generic;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
-
     /// <summary>
-    /// Represents a reference to a <see cref="FunctionDefinition"/>
+    /// Represents an object of any type
     /// </summary>
     [ProtoContract]
     [DataContract]
-    public class FunctionReference
+    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.AnyConverter))]
+    public class Any
+        : ProtoObject
     {
 
         /// <summary>
-        /// Gets/sets the referenced function's name
+        /// Initializes a new <see cref="Any"/>
         /// </summary>
-        [Required]
-        [ProtoMember(1)]
-        [DataMember(Order = 1)]
-        public virtual string RefName { get; set; }
+        public Any()
+        {
+
+        }
 
         /// <summary>
-        /// Gets/sets a <see cref="Any"/> that contains the parameters of the function to invoke
+        /// Innitializes a new <see cref="Any"/>
         /// </summary>
-        [ProtoMember(2)]
-        [DataMember(Order = 2)]
-        public virtual Any Arguments { get; set; }
-
-        /// <summary>
-        /// Gets/sets a <see href="https://spec.graphql.org/June2018/#sec-Selection-Sets">GraphQL selection set</see>
-        /// </summary>
-        [ProtoMember(3)]
-        [DataMember(Order = 3)]
-        public virtual string SelectionSet { get; set; }
+        /// <param name="properties">An <see cref="IDictionary{TKey, TValue}"/> containing the <see cref="Any"/>'s name/value property mappings</param>
+        public Any(IDictionary<string, object> properties)
+        {
+            foreach (var property in properties)
+            {
+                this.Set(property.Key, property.Value);
+            }
+        }
 
         /// <inheritdoc/>
-        public override string ToString()
+        [ProtoMember(1)]
+        protected new List<ProtoField> Fields
         {
-            return this.RefName;
+            get => base.Fields;
+            set => base.Fields = value;
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/AuthenticationDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/AuthenticationDefinition.cs
@@ -24,6 +24,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents a reusable definition of a workflow authentication mechanism
     /// </summary>
+    [DataContract]
+    [ProtoContract]
     public class AuthenticationDefinition
     {
 
@@ -33,6 +35,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
         [System.Text.Json.Serialization.JsonPropertyName("name")]
         [YamlMember(Alias = "name")]
+        [ProtoMember(1, Name = "name")]
+        [DataMember(Order = 1, Name = "name")]
         public virtual string Name { get; set; }
 
         /// <summary>
@@ -41,6 +45,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "scheme")]
         [System.Text.Json.Serialization.JsonPropertyName("scheme")]
         [YamlMember(Alias = "scheme")]
+        [ProtoMember(2, Name = "scheme")]
+        [DataMember(Order = 2, Name = "scheme")]
         public virtual AuthenticationScheme Scheme { get; set; }
 
         /// <summary>
@@ -49,6 +55,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "properties")]
         [System.Text.Json.Serialization.JsonPropertyName("properties")]
         [YamlMember(Alias = "properties")]
+        [ProtoMember(3, Name = "properties")]
+        [DataMember(Order = 3, Name = "properties")]
         protected virtual JToken PropertiesToken { get; set; }
 
         private AuthenticationProperties _Properties;
@@ -58,6 +66,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual AuthenticationProperties Properties
         {
             get
@@ -109,6 +119,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual string SecretRef
         {
             get

--- a/src/ServerlessWorkflow.Sdk/Models/AuthenticationProperties.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/AuthenticationProperties.cs
@@ -17,9 +17,16 @@
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents an object used to configure an authentication mechanism
     /// </summary>
+    [DataContract]
+    [ProtoContract]
+    [ProtoInclude(100, typeof(BasicAuthenticationProperties))]
+    [ProtoInclude(200, typeof(BearerAuthenticationProperties))]
+    [ProtoInclude(300, typeof(OAuth2AuthenticationProperties))]
+    [ProtoInclude(400, typeof(SecretBasedAuthenticationProperties))]
     public abstract class AuthenticationProperties
     {
 

--- a/src/ServerlessWorkflow.Sdk/Models/BasicAuthenticationProperties.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/BasicAuthenticationProperties.cs
@@ -15,13 +15,14 @@
  *
  */
 
-using YamlDotNet.Serialization;
-
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents an object used to configure a 'Basic' authentication scheme
     /// </summary>
+    [DataContract]
+    [ProtoContract]
     public class BasicAuthenticationProperties
         : AuthenticationProperties
     {
@@ -29,14 +30,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the username to use when authenticating
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Username { get; set; }
 
         /// <summary>
         /// Gets/sets the password to use when authenticating
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "password")]
-        [System.Text.Json.Serialization.JsonPropertyName("password")]
-        [YamlMember(Alias = "password")]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Password { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/BearerAuthenticationProperties.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/BearerAuthenticationProperties.cs
@@ -15,13 +15,14 @@
  *
  */
 
-using YamlDotNet.Serialization;
-
 namespace ServerlessWorkflow.Sdk.Models
 {
     /// <summary>
     /// Represents an object used to configure a 'Bearer' authentication scheme
     /// </summary>
+
+    [DataContract]
+    [ProtoContract]
     public class BearerAuthenticationProperties
         : AuthenticationProperties
     {
@@ -29,9 +30,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the token used to authenticate
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "token")]
-        [System.Text.Json.Serialization.JsonPropertyName("token")]
-        [YamlMember(Alias = "token")]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Token { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/BranchDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/BranchDefinition.cs
@@ -19,30 +19,41 @@ using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents a workflow execution branch
     /// </summary>
+    [DataContract]
+    [ProtoContract]
     public class BranchDefinition
     {
 
         /// <summary>
         /// gets/sets the branch's name
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Name { get; set; }
 
         /// <summary>
         /// Gets/sets the unique id of a workflow to be executed in this branch
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string WorkflowId { get; set; }
 
         /// <summary>
         /// Gets/sets a value that specifies how actions are to be performed (in sequence of parallel)
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual ActionExecutionMode ActionMode { get; set; }
 
         /// <summary>
         /// Gets/sets an <see cref="List{T}"/> containing the actions to be executed in this branch
         /// </summary>
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         public virtual List<ActionDefinition> Actions { get; set; } = new List<ActionDefinition>();
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Models/BranchDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/BranchDefinition.cs
@@ -15,6 +15,7 @@
  *
  */
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -43,6 +44,46 @@ namespace ServerlessWorkflow.Sdk.Models
         /// Gets/sets an <see cref="List{T}"/> containing the actions to be executed in this branch
         /// </summary>
         public virtual List<ActionDefinition> Actions { get; set; } = new List<ActionDefinition>();
+
+        /// <summary>
+        /// Gets the <see cref="ActionDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="ActionDefinition"/> to get</param>
+        /// <returns>The <see cref="ActionDefinition"/> with the specified name</returns>
+        public virtual ActionDefinition GetAction(string name)
+        {
+            return this.Actions.FirstOrDefault(s => s.Name == name);
+        }
+
+        /// <summary>
+        /// Attempts to get the <see cref="ActionDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="ActionDefinition"/> to get</param>
+        /// <param name="action">The <see cref="ActionDefinition"/> with the specified name</param>
+        /// <returns>A boolean indicating whether or not a <see cref="ActionDefinition"/> with the specified name could be found</returns>
+        public virtual bool TryGetAction(string name, out ActionDefinition action)
+        {
+            action = this.GetAction(name);
+            return action != null;
+        }
+
+        /// <summary>
+        /// Attempts to get the next <see cref="ActionDefinition"/> in the pipeline
+        /// </summary>
+        /// <param name="previousActionName">The name of the <see cref="ActionDefinition"/> to get the next <see cref="ActionDefinition"/> for</param>
+        /// <param name="action">The next <see cref="ActionDefinition"/>, if any</param>
+        /// <returns>A boolean indicating whether or not there is a next <see cref="ActionDefinition"/> in the pipeline</returns>
+        public virtual bool TryGetNextAction(string previousActionName, out ActionDefinition action)
+        {
+            action = null;
+            ActionDefinition previousAction = this.Actions.FirstOrDefault(a => a.Name == previousActionName);
+            int previousActionIndex = this.Actions.ToList().IndexOf(previousAction);
+            int nextIndex = previousActionIndex + 1;
+            if (nextIndex >= this.Actions.Count())
+                return false;
+            action = this.Actions.ElementAt(nextIndex);
+            return true;
+        }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/ServerlessWorkflow.Sdk/Models/CallbackStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/CallbackStateDefinition.cs
@@ -25,6 +25,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// Represents a workflow state that performs an action, then waits for the callback event that denotes completion of the action
     /// </summary>
     [DiscriminatorValue(StateType.Callback)]
+    [ProtoContract]
+    [DataContract]
     public class CallbackStateDefinition
         : StateDefinition
     {
@@ -41,6 +43,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the action to be executed
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual ActionDefinition Action { get; set; }
 
         /// <summary>
@@ -49,6 +53,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "eventRef")]
         [System.Text.Json.Serialization.JsonPropertyName("eventRef")]
         [YamlMember(Alias = "eventRef")]
+        [ProtoMember(2, Name = "eventRef")]
+        [DataMember(Order = 2, Name = "eventRef")]
         public virtual string Event { get; set; }
 
         /// <summary>
@@ -56,6 +62,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.Iso8601TimeSpanConverter))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter))]
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual TimeSpan? Timeout { get; set; }
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Models/CronDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/CronDefinition.cs
@@ -20,9 +20,12 @@ using System.ComponentModel.DataAnnotations;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents a CRON expression definition
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class CronDefinition
     {
 
@@ -31,11 +34,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Expression { get; set; }
 
         /// <summary>
         /// Gets/sets the date and time when the cron expression invocation is no longer valid
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual DateTime? ValidUntil { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/DataCaseDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/DataCaseDefinition.cs
@@ -21,6 +21,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents a data-based <see cref="SwitchCaseDefinition"/>
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class DataCaseDefinition
         : SwitchCaseDefinition
     {
@@ -28,6 +30,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets an expression evaluated against state data. True if results are not empty
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Condition { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/DataInputSchemaDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/DataInputSchemaDefinition.cs
@@ -17,9 +17,12 @@
 using System.ComponentModel.DataAnnotations;
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents the object used to configure a <see cref="WorkflowDefinition"/>'s data input schema
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class DataInputSchemaDefinition
     {
 
@@ -28,11 +31,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Schema { get; set; }
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to terminate the <see cref="WorkflowDefinition"/>'s execution whenever the validation of the input data fails. Defaults to true.
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual bool FailOnValidationError { get; set; } = true;
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/DefaultConditionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/DefaultConditionDefinition.cs
@@ -20,10 +20,13 @@ using YamlDotNet.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents an object used to define the transition of the workflow if there is no matching data conditions or event timeout is reached
     /// </summary>
-    public class DefaultDefinition
+    [ProtoContract]
+    [DataContract]
+    public class DefaultConditionDefinition
     {
 
         /// <summary>
@@ -32,7 +35,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "transition")]
         [System.Text.Json.Serialization.JsonPropertyName("transition")]
         [YamlMember(Alias = "transition")]
-        protected virtual JToken TransitionToken { get; set; }
+        [ProtoMember(1, Name = "transition")]
+        [DataMember(Order = 1, Name = "transition")]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<TransitionDefinition, string>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<TransitionDefinition, string>))]
+        protected virtual OneOf<TransitionDefinition, string> TransitionToken { get; set; }
 
         private TransitionDefinition _Transition;
         /// <summary>
@@ -41,6 +48,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual TransitionDefinition Transition
         {
             get
@@ -48,17 +57,23 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Transition == null
                     && this.TransitionToken != null)
                 {
-                    if (this.TransitionToken.Type == JTokenType.String)
-                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.ToString() };
+                    if (this.TransitionToken.Value1 == null)
+                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.Value2 };
                     else
-                        this._Transition = this.TransitionToken.ToObject<TransitionDefinition>();
+                        this._Transition = this.TransitionToken.Value1;
                 }
                 return this._Transition;
             }
             set
             {
-                this._Transition = value ?? throw new ArgumentNullException(nameof(value));
-                this.TransitionToken = JToken.FromObject(value);
+                if (value == null)
+                {
+                    this._Transition = null;
+                    this.TransitionToken = null;
+                    return;
+                }
+                this._Transition = value;
+                this.TransitionToken = new(value);
             }
         }
 
@@ -68,7 +83,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
         [System.Text.Json.Serialization.JsonPropertyName("end")]
         [YamlMember(Alias = "end")]
-        protected virtual JToken EndToken { get; set; }
+        [ProtoMember(2, Name = "end")]
+        [DataMember(Order = 2, Name = "end")]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<EndDefinition, bool>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<EndDefinition, bool>))]
+        protected virtual OneOf<EndDefinition, bool> EndToken { get; set; }
 
         private EndDefinition _End;
         /// <summary>
@@ -77,6 +96,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual EndDefinition End
         {
             get
@@ -84,11 +105,11 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._End == null
                     && this.EndToken != null)
                 {
-                    if (this.EndToken.Type == JTokenType.Boolean || this.EndToken.Type == JTokenType.String
-                        && this.EndToken.ToObject<bool>())
-                        this._End = new EndDefinition();
+                    if (this.EndToken.Value1 == null
+                        && this.EndToken.Value2)
+                        this._End = new();
                     else
-                        this._End = this.EndToken.ToObject<EndDefinition>();
+                        this._End = this.EndToken.Value1;
                 }
                 return this._End;
             }
@@ -101,7 +122,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._End = value;
-                this.EndToken = JToken.FromObject(value);
+                this.EndToken = new(value);
             }
         }
 

--- a/src/ServerlessWorkflow.Sdk/Models/DefaultConditionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/DefaultConditionDefinition.cs
@@ -15,8 +15,6 @@
  *
  */
 using Newtonsoft.Json.Linq;
-using System;
-using YamlDotNet.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -32,99 +30,20 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets a <see cref="JToken"/> that represents the next transition of the workflow if there is valid matches
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "transition")]
-        [System.Text.Json.Serialization.JsonPropertyName("transition")]
-        [YamlMember(Alias = "transition")]
-        [ProtoMember(1, Name = "transition")]
-        [DataMember(Order = 1, Name = "transition")]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<TransitionDefinition, string>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<TransitionDefinition, string>))]
-        protected virtual OneOf<TransitionDefinition, string> TransitionToken { get; set; }
-
-        private TransitionDefinition _Transition;
-        /// <summary>
-        /// Gets/sets an object used to define the next transition of the workflow if there is valid matches
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual TransitionDefinition Transition
-        {
-            get
-            {
-                if (this._Transition == null
-                    && this.TransitionToken != null)
-                {
-                    if (this.TransitionToken.Value1 == null)
-                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.Value2 };
-                    else
-                        this._Transition = this.TransitionToken.Value1;
-                }
-                return this._Transition;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    this._Transition = null;
-                    this.TransitionToken = null;
-                    return;
-                }
-                this._Transition = value;
-                this.TransitionToken = new(value);
-            }
-        }
+        public virtual OneOf<TransitionDefinition, string> Transition { get; set; }
 
         /// <summary>
         /// Gets/sets a <see cref="JToken"/> that represents the object used to configure the end of the workflow
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
-        [System.Text.Json.Serialization.JsonPropertyName("end")]
-        [YamlMember(Alias = "end")]
-        [ProtoMember(2, Name = "end")]
-        [DataMember(Order = 2, Name = "end")]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<EndDefinition, bool>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<EndDefinition, bool>))]
-        protected virtual OneOf<EndDefinition, bool> EndToken { get; set; }
-
-        private EndDefinition _End;
-        /// <summary>
-        /// Gets/sets an object used to configure the end of the workflow
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual EndDefinition End
-        {
-            get
-            {
-                if (this._End == null
-                    && this.EndToken != null)
-                {
-                    if (this.EndToken.Value1 == null
-                        && this.EndToken.Value2)
-                        this._End = new();
-                    else
-                        this._End = this.EndToken.Value1;
-                }
-                return this._End;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    this._End = null;
-                    this.EndToken = null;
-                    return;
-                }
-                this._End = value;
-                this.EndToken = new(value);
-            }
-        }
+        public virtual OneOf<EndDefinition, bool> End { get; set; }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/EndDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EndDefinition.cs
@@ -22,6 +22,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to explicitly define execution completion of a workflow instance or workflow execution path.
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class EndDefinition
         : StateOutcomeDefinition
     {
@@ -29,16 +31,22 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to terminate the executing workflow. If true, completes all execution flows in the given workflow instance. Defaults to false.
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual bool Terminate { get; set; } = false;
 
         /// <summary>
         /// Gets/sets an <see cref="IEnumerable{T}"/> containing the events that should be produced
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual IEnumerable<ProduceEventDefinition> ProduceEvents { get; set; }
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not the state should trigger compensation. Default is false.
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual bool Compensate { get; set; } = false;
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ErrorHandlerDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ErrorHandlerDefinition.cs
@@ -15,15 +15,17 @@
  *
  */
 using Newtonsoft.Json.Linq;
-using System;
 using System.ComponentModel.DataAnnotations;
 using YamlDotNet.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents the definition of a workflow error handler
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ErrorHandlerDefinition
     {
 
@@ -32,11 +34,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Newtonsoft.Json.JsonRequired]
         [Required]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Error { get; set; }
 
         /// <summary>
         /// Gets/sets the error code. Can be used in addition to the name to help runtimes resolve to technical errors/exceptions. Should not be defined if error is set to '*'.
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Code { get; set; }
 
         /// <summary>
@@ -45,6 +51,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "retryRef")]
         [System.Text.Json.Serialization.JsonPropertyName("retryRef")]
         [YamlMember(Alias = "retryRef")]
+        [ProtoMember(3, Name = "retryRef")]
+        [DataMember(Order = 3, Name = "retryRef")]
         public virtual string Retry { get; set; }
 
         /// <summary>
@@ -53,7 +61,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "transition")]
         [System.Text.Json.Serialization.JsonPropertyName("transition")]
         [YamlMember(Alias = "transition")]
-        protected virtual JToken TransitionToken { get; set; }
+        [ProtoMember(4, Name = "transition")]
+        [DataMember(Order = 4, Name = "transition")]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<TransitionDefinition, string>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<TransitionDefinition, string>))]
+        protected virtual OneOf<TransitionDefinition, string> TransitionToken { get; set; }
 
         private TransitionDefinition _Transition;
         /// <summary>
@@ -62,6 +74,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual TransitionDefinition Transition
         {
             get
@@ -69,17 +83,23 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Transition == null
                     && this.TransitionToken != null)
                 {
-                    if (this.TransitionToken.Type == JTokenType.String)
-                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.ToString() };
+                    if (this.TransitionToken.Value1 == null)
+                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.Value2 };
                     else
-                        this._Transition = this.TransitionToken.ToObject<TransitionDefinition>();
+                        this._Transition = this.TransitionToken.Value1;
                 }
                 return this._Transition;
             }
             set
             {
-                this._Transition = value ?? throw new ArgumentNullException(nameof(value));
-                this.TransitionToken = JToken.FromObject(value);
+                if (value == null)
+                {
+                    this._Transition = null;
+                    this.TransitionToken = null;
+                    return;
+                }
+                this._Transition = value;
+                this.TransitionToken = new(value);
             }
         }
 
@@ -89,7 +109,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
         [System.Text.Json.Serialization.JsonPropertyName("end")]
         [YamlMember(Alias = "end")]
-        protected virtual JToken EndToken { get; set; }
+        [ProtoMember(5, Name = "end")]
+        [DataMember(Order = 5, Name = "end")]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<EndDefinition, bool>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<EndDefinition, bool>))]
+        protected virtual OneOf<EndDefinition, bool> EndToken { get; set; }
 
         private EndDefinition _End;
         /// <summary>
@@ -98,6 +122,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual EndDefinition End
         {
             get
@@ -105,11 +131,11 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._End == null
                     && this.EndToken != null)
                 {
-                    if (this.EndToken.Type == JTokenType.Boolean || this.EndToken.Type == JTokenType.String
-                        && this.EndToken.ToObject<bool>())
-                        this._End = new EndDefinition();
+                    if (this.EndToken.Value1 == null
+                        && this.EndToken.Value2)
+                        this._End = new();
                     else
-                        this._End = this.EndToken.ToObject<EndDefinition>();
+                        this._End = this.EndToken.Value1;
                 }
                 return this._End;
             }
@@ -122,7 +148,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._End = value;
-                this.EndToken = JToken.FromObject(value);
+                this.EndToken = new(value);
             }
         }
 

--- a/src/ServerlessWorkflow.Sdk/Models/ErrorHandlerDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ErrorHandlerDefinition.cs
@@ -58,99 +58,20 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the <see cref="JToken"/> that represents the <see cref="ErrorHandlerDefinition"/>'s <see cref="TransitionDefinition"/>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "transition")]
-        [System.Text.Json.Serialization.JsonPropertyName("transition")]
-        [YamlMember(Alias = "transition")]
-        [ProtoMember(4, Name = "transition")]
-        [DataMember(Order = 4, Name = "transition")]
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<TransitionDefinition, string>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<TransitionDefinition, string>))]
-        protected virtual OneOf<TransitionDefinition, string> TransitionToken { get; set; }
-
-        private TransitionDefinition _Transition;
-        /// <summary>
-        /// Gets/sets the object used to configre the transition to execute on error.
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual TransitionDefinition Transition
-        {
-            get
-            {
-                if (this._Transition == null
-                    && this.TransitionToken != null)
-                {
-                    if (this.TransitionToken.Value1 == null)
-                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.Value2 };
-                    else
-                        this._Transition = this.TransitionToken.Value1;
-                }
-                return this._Transition;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    this._Transition = null;
-                    this.TransitionToken = null;
-                    return;
-                }
-                this._Transition = value;
-                this.TransitionToken = new(value);
-            }
-        }
+        public virtual OneOf<TransitionDefinition, string> Transition { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="JToken"/> that represents the <see cref="ErrorHandlerDefinition"/>'s <see cref="EndDefinition"/>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
-        [System.Text.Json.Serialization.JsonPropertyName("end")]
-        [YamlMember(Alias = "end")]
-        [ProtoMember(5, Name = "end")]
-        [DataMember(Order = 5, Name = "end")]
+        [ProtoMember(5)]
+        [DataMember(Order = 5)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<EndDefinition, bool>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<EndDefinition, bool>))]
-        protected virtual OneOf<EndDefinition, bool> EndToken { get; set; }
-
-        private EndDefinition _End;
-        /// <summary>
-        /// Gets/sets the object used to configre the way the workflow ends on error
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual EndDefinition End
-        {
-            get
-            {
-                if (this._End == null
-                    && this.EndToken != null)
-                {
-                    if (this.EndToken.Value1 == null
-                        && this.EndToken.Value2)
-                        this._End = new();
-                    else
-                        this._End = this.EndToken.Value1;
-                }
-                return this._End;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    this._End = null;
-                    this.EndToken = null;
-                    return;
-                }
-                this._End = value;
-                this.EndToken = new(value);
-            }
-        }
+        public virtual OneOf<EndDefinition, bool> End { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/ServerlessWorkflow.Sdk/Models/EventCaseDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventCaseDefinition.cs
@@ -18,9 +18,12 @@ using YamlDotNet.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents the definition of an event-based <see cref="SwitchStateDefinition"/>
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class EventCaseDefinition
         : SwitchCaseDefinition
     {
@@ -31,6 +34,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "eventRef")]
         [System.Text.Json.Serialization.JsonPropertyName("eventRef")]
         [YamlMember(Alias = "eventRef")]
+        [ProtoMember(1, Name = "eventRef")]
+        [DataMember(Order = 1, Name = "eventRef")]
         public string Event { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/EventCorrelationDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventCorrelationDefinition.cs
@@ -21,6 +21,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to define the way to correlate a cloud event
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class EventCorrelationDefinition
     {
 
@@ -29,11 +31,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string ContextAttributeName { get; set; }
 
         /// <summary>
         /// Gets/sets the cloud event Extension Context Attribute value
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string ContextAttributeValue { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/EventDataFilterDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventDataFilterDefinition.cs
@@ -20,17 +20,23 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to configure how event data is to be filtered and added to or merged with the state data
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class EventDataFilterDefinition
     {
 
         /// <summary>
         /// Gets/sets an expression that filters the event data (payload)
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Data { get; set; }
 
         /// <summary>
         /// Gets/sets an expression that selects a state data element to which the action results should be added/merged into. If not specified denotes the top-level state data element
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string ToStateData { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/EventDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventDefinition.cs
@@ -14,8 +14,6 @@
  * limitations under the License.
  *
  */
-using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using YamlDotNet.Serialization;
@@ -26,6 +24,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to define events and their correlations
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class EventDefinition
     {
 
@@ -34,6 +34,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Name { get; set; }
 
         /// <summary>
@@ -41,16 +43,22 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Source { get; set; }
 
         /// <summary>
         /// Gets/sets the cloud event type
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual string Type { get; set; }
 
         /// <summary>
         /// Gets/sets a value that defines the CloudEvent as either '<see cref="EventKind.Consumed"/>' or '<see cref="EventKind.Produced"/>' by the workflow. Default is '<see cref="EventKind.Consumed"/>'.
         /// </summary>
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         public virtual EventKind Kind { get; set; } = EventKind.Consumed;
 
         /// <summary>
@@ -59,11 +67,15 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "correlation"), MinLength(1)]
         [System.Text.Json.Serialization.JsonPropertyName("correlation")]
         [YamlMember(Alias = "correlation")]
+        [ProtoMember(5, Name = "correlation")]
+        [DataMember(Order = 5, Name = "correlation")]
         public virtual List<EventCorrelationDefinition> Correlations { get; set; } = new List<EventCorrelationDefinition>();
 
         /// <summary>
         /// Gets/sets the <see cref="EventDefinition"/>'s metadata
         /// </summary>
+        [ProtoMember(6)]
+        [DataMember(Order = 6)]
         public virtual Any Metadata { get; set; }
 
         /// <inheritdoc/>

--- a/src/ServerlessWorkflow.Sdk/Models/EventDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventDefinition.cs
@@ -64,7 +64,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the <see cref="EventDefinition"/>'s metadata
         /// </summary>
-        public virtual JObject Metadata { get; set; } = new JObject();
+        public virtual Any Metadata { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/ServerlessWorkflow.Sdk/Models/EventReference.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventReference.cs
@@ -23,6 +23,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents a reference to an <see cref="EventDefinition"/>
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class EventReference
     {
 
@@ -33,6 +35,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonRequired, Newtonsoft.Json.JsonProperty(PropertyName = "triggerEventRef")]
         [System.Text.Json.Serialization.JsonPropertyName("triggerEventRef")]
         [YamlMember(Alias = "triggerEventRef")]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string TriggerEvent { get; set; }
 
         /// <summary>
@@ -42,6 +46,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonRequired, Newtonsoft.Json.JsonProperty(PropertyName = "resultEventRef")]
         [System.Text.Json.Serialization.JsonPropertyName("resultEventRef")]
         [YamlMember(Alias = "resultEventRef")]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string ResultEvent { get; set; }
 
         /// <summary>
@@ -49,12 +55,18 @@ namespace ServerlessWorkflow.Sdk.Models
         /// If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by 'triggerEventRef'. 
         /// If object type, a custom object to become the data (payload) of the event referenced by 'triggerEventRef'.
         /// </summary>
-        public virtual JToken Data { get; set; }
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<Any, string>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<Any, string>))]
+        public virtual OneOf<Any, string> Data { get; set; }
 
         /// <summary>
         /// Gets/sets additional extension context attributes to the produced event
         /// </summary>
-        public virtual JObject ContextAttributes { get; set; } = new JObject();
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
+        public virtual Any ContextAttributes { get; set; }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/EventStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventStateDefinition.cs
@@ -19,6 +19,7 @@ using System.ComponentModel.DataAnnotations;
 using YamlDotNet.Serialization;
 using System.Collections.Generic;
 using ServerlessWorkflow.Sdk.Serialization;
+using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -60,6 +61,36 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.Iso8601TimeSpanConverter))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter))]
         public virtual TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="EventStateTriggerDefinition"/> with the specified id
+        /// </summary>
+        /// <param name="id">The id of the <see cref="EventStateTriggerDefinition"/> to get</param>
+        /// <returns>The <see cref="EventStateTriggerDefinition"/> with the specified id</returns>
+        public virtual EventStateTriggerDefinition GetTrigger(int id)
+        {
+            return this.Triggers.ElementAt(id);
+        }
+
+        /// <summary>
+        /// Attempts to get the <see cref="EventStateTriggerDefinition"/> with the specified id
+        /// </summary>
+        /// <param name="id">The name of the <see cref="EventStateTriggerDefinition"/> to get</param>
+        /// <param name="trigger">The <see cref="EventStateTriggerDefinition"/> with the specified id</param>
+        /// <returns>A boolean indicating whether or not a <see cref="EventStateTriggerDefinition"/> with the specified id could be found</returns>
+        public virtual bool TryGetTrigger(int id, out EventStateTriggerDefinition trigger)
+        {
+            trigger = null;
+            try
+            {
+                trigger = this.GetTrigger(id);
+            }
+            catch
+            {
+                return false;
+            }
+            return trigger != null;
+        }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/EventStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventStateDefinition.cs
@@ -27,6 +27,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// Represents a workflow state that awaits one or more events and perform actions when they are received
     /// </summary>
     [DiscriminatorValue(StateType.Event)]
+    [ProtoContract]
+    [DataContract]
     public class EventStateDefinition
         : StateDefinition
     {
@@ -44,6 +46,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// Gets/sets a boolean indicating whether or not the <see cref="EventStateDefinition"/> awaits one or all of defined events.
         /// If 'true', consuming one of the defined events causes its associated actions to be performed. If 'false', all of the defined events must be consumed in order for actions to be performed. Defaults to 'true'.
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual bool Exclusive { get; set; } = true;
 
         /// <summary>
@@ -53,11 +57,15 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonRequired, Newtonsoft.Json.JsonProperty(PropertyName = "onEvents")]
         [System.Text.Json.Serialization.JsonPropertyName("onEvents")]
         [YamlMember(Alias = "onEvents")]
+        [ProtoMember(2, Name = "onEvents")]
+        [DataMember(Order = 2, Name = "onEvents")]
         public virtual List<EventStateTriggerDefinition> Triggers { get; set; } = new List<EventStateTriggerDefinition>();
 
         /// <summary>
         /// Gets/sets the duration to wait for incoming events
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.Iso8601TimeSpanConverter))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter))]
         public virtual TimeSpan? Timeout { get; set; }

--- a/src/ServerlessWorkflow.Sdk/Models/EventStateTriggerDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventStateTriggerDefinition.cs
@@ -25,6 +25,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents the definition of an <see cref="EventStateDefinition"/>'s trigger
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class EventStateTriggerDefinition
     {
 
@@ -35,16 +37,22 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "eventRefs"), Newtonsoft.Json.JsonRequired]
         [System.Text.Json.Serialization.JsonPropertyName("eventRefs")]
         [YamlMember(Alias = "eventRefs")]
+        [ProtoMember(1, Name = "eventRefs")]
+        [DataMember(Order = 1, Name = "eventRefs")]
         public virtual List<string> Events { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets/sets a value that specifies how actions are to be performed (in sequence of parallel)
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual ActionExecutionMode ActionMode { get; set; }
 
         /// <summary>
         /// Gets/sets an <see cref="List{T}"/> containing the actions to be performed if expression matches
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual List<ActionDefinition> Actions { get; set; } = new List<ActionDefinition>();
 
         /// <summary>
@@ -53,6 +61,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "eventDataFilter")]
         [System.Text.Json.Serialization.JsonPropertyName("eventDataFilter")]
         [YamlMember(Alias = "eventDataFilter")]
+        [ProtoMember(4, Name = "eventDataFilter")]
+        [DataMember(Order = 4, Name = "eventDataFilter")]
         public virtual EventDataFilterDefinition DataFilter { get; set; } = new EventDataFilterDefinition();
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Models/EventStateTriggerDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventStateTriggerDefinition.cs
@@ -17,6 +17,7 @@
 using YamlDotNet.Serialization;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -53,6 +54,46 @@ namespace ServerlessWorkflow.Sdk.Models
         [System.Text.Json.Serialization.JsonPropertyName("eventDataFilter")]
         [YamlMember(Alias = "eventDataFilter")]
         public virtual EventDataFilterDefinition DataFilter { get; set; } = new EventDataFilterDefinition();
+
+        /// <summary>
+        /// Gets the <see cref="ActionDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="ActionDefinition"/> to get</param>
+        /// <returns>The <see cref="ActionDefinition"/> with the specified name</returns>
+        public virtual ActionDefinition GetAction(string name)
+        {
+            return this.Actions.FirstOrDefault(s => s.Name == name);
+        }
+
+        /// <summary>
+        /// Attempts to get the <see cref="ActionDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="ActionDefinition"/> to get</param>
+        /// <param name="action">The <see cref="ActionDefinition"/> with the specified name</param>
+        /// <returns>A boolean indicating whether or not a <see cref="ActionDefinition"/> with the specified name could be found</returns>
+        public virtual bool TryGetAction(string name, out ActionDefinition action)
+        {
+            action = this.GetAction(name);
+            return action != null;
+        }
+
+        /// <summary>
+        /// Attempts to get the next <see cref="ActionDefinition"/> in the pipeline
+        /// </summary>
+        /// <param name="previousActionName">The name of the <see cref="ActionDefinition"/> to get the next <see cref="ActionDefinition"/> for</param>
+        /// <param name="action">The next <see cref="ActionDefinition"/>, if any</param>
+        /// <returns>A boolean indicating whether or not there is a next <see cref="ActionDefinition"/> in the pipeline</returns>
+        public virtual bool TryGetNextAction(string previousActionName, out ActionDefinition action)
+        {
+            action = null;
+            ActionDefinition previousAction = this.Actions.FirstOrDefault(a => a.Name == previousActionName);
+            int previousActionIndex = this.Actions.ToList().IndexOf(previousAction);
+            int nextIndex = previousActionIndex + 1;
+            if (nextIndex >= this.Actions.Count)
+                return false;
+            action = this.Actions.ElementAt(nextIndex);
+            return true;
+        }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/ExecutionTimeoutDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ExecutionTimeoutDefinition.cs
@@ -23,6 +23,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to define the execution timeout for a workflow instance
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ExecutionTimeoutDefinition
     {
 
@@ -33,16 +35,22 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonRequired]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.Iso8601TimeSpanConverter))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter))]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual TimeSpan Duration { get; set; }
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to terminate the workflow execution.
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual bool Interrupt { get; set; } = false;
 
         /// <summary>
         /// Gets/sets the name of a workflow state to be executed before workflow instance is terminated
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual string RunBefore { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ExternalArrayDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ExternalArrayDefinition.cs
@@ -18,9 +18,12 @@ using Newtonsoft.Json.Linq;
 using System;
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents an external definition reference
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ExternalArrayDefinition
         : JArray
     {
@@ -48,11 +51,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets the <see cref="Uri"/> used to reference the file that defines the element described by the <see cref="ExternalArrayDefinition"/>
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual Uri DefinitionUri { get; private set; }
 
         /// <summary>
         /// Gets a boolean indicating whether or not the <see cref="ExternalArrayDefinition"/> has been loaded
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual bool Loaded { get; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ExternalDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ExternalDefinition.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json.Linq;
 using System;
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents an external definition reference
     /// </summary>

--- a/src/ServerlessWorkflow.Sdk/Models/ExternalDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ExternalDefinition.cs
@@ -22,6 +22,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an external definition reference
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ExternalDefinition
         : JObject
     {
@@ -49,11 +51,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets the <see cref="Uri"/> used to reference the file that defines the element described by the <see cref="ExternalDefinition"/>
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual Uri DefinitionUri { get; private set; }
 
         /// <summary>
         /// Gets a boolean indicating whether or not the <see cref="ExternalDefinition"/> has been loaded
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual bool Loaded { get; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ExternalDefinitionCollection.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ExternalDefinitionCollection.cs
@@ -23,6 +23,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// Represents a <see cref="List{T}"/> that can be loaded from an external definition file
     /// </summary>
     /// <typeparam name="T">The type of elements contained by the <see cref="ExternalDefinitionCollection{T}"/></typeparam>
+    [ProtoContract]
+    [DataContract]
     public class ExternalDefinitionCollection<T>
         : List<T>
     {
@@ -60,11 +62,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets the <see cref="Uri"/> used to reference the file that defines the elements contained by the <see cref="ExternalDefinitionCollection{T}"/>
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual Uri DefinitionUri { get; private set; }
 
         /// <summary>
         /// Gets a boolean indicating whether or not the <see cref="ExternalDefinitionCollection{T}"/> has been loaded
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual bool Loaded { get; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ExternalJSchema.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ExternalJSchema.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json.Schema;
 using System;
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents an external definition reference
     /// </summary>

--- a/src/ServerlessWorkflow.Sdk/Models/ForEachStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ForEachStateDefinition.cs
@@ -17,6 +17,7 @@
 using YamlDotNet.Serialization;
 using System.Collections.Generic;
 using ServerlessWorkflow.Sdk.Serialization;
+using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -74,6 +75,46 @@ namespace ServerlessWorkflow.Sdk.Models
         /// Gets/sets the unique Id of a workflow to be executed for each of the elements of <see cref="InputCollection"/>
         /// </summary>
         public virtual string WorkflowId { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="ActionDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="ActionDefinition"/> to get</param>
+        /// <returns>The <see cref="ActionDefinition"/> with the specified name</returns>
+        public virtual ActionDefinition GetAction(string name)
+        {
+            return this.Actions.FirstOrDefault(s => s.Name == name);
+        }
+
+        /// <summary>
+        /// Attempts to get the <see cref="ActionDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="ActionDefinition"/> to get</param>
+        /// <param name="action">The <see cref="ActionDefinition"/> with the specified name</param>
+        /// <returns>A boolean indicating whether or not a <see cref="ActionDefinition"/> with the specified name could be found</returns>
+        public virtual bool TryGetAction(string name, out ActionDefinition action)
+        {
+            action = this.GetAction(name);
+            return action != null;
+        }
+
+        /// <summary>
+        /// Attempts to get the next <see cref="ActionDefinition"/> in the pipeline
+        /// </summary>
+        /// <param name="previousActionName">The name of the <see cref="ActionDefinition"/> to get the next <see cref="ActionDefinition"/> for</param>
+        /// <param name="action">The next <see cref="ActionDefinition"/>, if any</param>
+        /// <returns>A boolean indicating whether or not there is a next <see cref="ActionDefinition"/> in the pipeline</returns>
+        public virtual bool TryGetNextAction(string previousActionName, out ActionDefinition action)
+        {
+            action = null;
+            ActionDefinition previousAction = this.Actions.FirstOrDefault(a => a.Name == previousActionName);
+            int previousActionIndex = this.Actions.ToList().IndexOf(previousAction);
+            int nextIndex = previousActionIndex + 1;
+            if (nextIndex >= this.Actions.Count)
+                return false;
+            action = this.Actions.ElementAt(nextIndex);
+            return true;
+        }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/ForEachStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ForEachStateDefinition.cs
@@ -25,6 +25,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// Represents a workflow state that executes a set of defined actions or workflows for each element of a data array
     /// </summary>
     [DiscriminatorValue(StateType.ForEach)]
+    [ProtoContract]
+    [DataContract]
     public class ForEachStateDefinition
         : StateDefinition
     {
@@ -41,11 +43,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// gets/sets an expression selecting an array element of the states data
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string InputCollection { get; set; }
 
         /// <summary>
         /// Gets/sets an expression specifying an array element of the states data to add the results of each iteration
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string OutputCollection { get; set; }
 
         /// <summary>
@@ -54,26 +60,36 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "iterationParam")]
         [System.Text.Json.Serialization.JsonPropertyName("iterationParam")]
         [YamlMember(Alias = "iterationParam")]
+        [ProtoMember(3, Name = "iterationParam")]
+        [DataMember(Order = 3, Name = "iterationParam")]
         public virtual string IterationParameter { get; set; }
 
         /// <summary>
         /// Gets/sets a uint that specifies how upper bound on how many iterations may run in parallel
         /// </summary>
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         public virtual uint? Max { get; set; }
 
         /// <summary>
         /// Gets/sets a value used to configure the way the actions of each iterations should be executed
         /// </summary>
+        [ProtoMember(5)]
+        [DataMember(Order = 5)]
         public virtual ActionExecutionMode ActionMode { get; set; }
 
         /// <summary>
         /// Gets/sets an <see cref="List{T}"/> of actions to be executed for each of the elements of the <see cref="InputCollection"/>
         /// </summary>
+        [ProtoMember(6)]
+        [DataMember(Order = 6)]
         public virtual List<ActionDefinition> Actions { get; set; } = new List<ActionDefinition>();
 
         /// <summary>
         /// Gets/sets the unique Id of a workflow to be executed for each of the elements of <see cref="InputCollection"/>
         /// </summary>
+        [ProtoMember(7)]
+        [DataMember(Order = 7)]
         public virtual string WorkflowId { get; set; }
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Models/FunctionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/FunctionDefinition.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-using Newtonsoft.Json.Linq;
 using System.ComponentModel.DataAnnotations;
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -22,6 +21,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to define a reusable function
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class FunctionDefinition
     {
 
@@ -30,6 +31,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Name { get; set; }
 
         /// <summary>
@@ -38,21 +41,29 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Operation { get; set; }
 
         /// <summary>
         /// Gets/sets the type of the defined function. Defaults to '<see cref="FunctionType.Rest"/>'
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual FunctionType Type { get; set; } = FunctionType.Rest;
 
         /// <summary>
         /// Gets/sets the reference to the <see cref="AuthenticationDefinition"/> to use when invoking the function. Ignored when <see cref="Type"/> has been set to <see cref="FunctionType.Expression"/>
         /// </summary>
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         public virtual string AuthRef { get; set; }
 
         /// <summary>
         /// Gets/sets the function's metadata
         /// </summary>
+        [ProtoMember(5)]
+        [DataMember(Order = 5)]
         public virtual Any Metadata { get; set; }
 
         /// <inheritdoc/>

--- a/src/ServerlessWorkflow.Sdk/Models/FunctionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/FunctionDefinition.cs
@@ -53,7 +53,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the function's metadata
         /// </summary>
-        public virtual JObject Metadata { get; set; } = new JObject();
+        public virtual Any Metadata { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/ServerlessWorkflow.Sdk/Models/InjectStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/InjectStateDefinition.cs
@@ -14,11 +14,11 @@
  * limitations under the License.
  *
  */
-using Newtonsoft.Json.Linq;
 using ServerlessWorkflow.Sdk.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents a workflow state that injects static data into state data input
     /// </summary>
@@ -37,9 +37,11 @@ namespace ServerlessWorkflow.Sdk.Models
         }
 
         /// <summary>
-        /// Gets/sets the <see cref="JToken"/> which can be set as state's data input and can be manipulated via filter
+        /// Gets/sets the <see cref="Any"/> which can be set as state's data input and can be manipulated via filter
         /// </summary>
-        public virtual JToken Data { get; set; }
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
+        public virtual Any Data { get; set; }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/OAuth2AuthenticationProperties.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/OAuth2AuthenticationProperties.cs
@@ -16,7 +16,6 @@
  */
 using System;
 using System.Collections.Generic;
-using YamlDotNet.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -24,6 +23,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to configure an 'OAuth2' authentication scheme
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class OAuth2AuthenticationProperties
         : AuthenticationProperties
     {
@@ -31,89 +32,78 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the OAuth2 grant type to use
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "grantType")]
-        [System.Text.Json.Serialization.JsonPropertyName("grantType")]
-        [YamlMember(Alias = "grantType")]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual OAuth2GrantType GrantType { get; set; }
 
         /// <summary>
         /// Gets/sets the uri of the OAuth2 authority to use to generate an access token
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "authority")]
-        [System.Text.Json.Serialization.JsonPropertyName("authority")]
-        [YamlMember(Alias = "authority")]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual Uri Authority { get; set; }
 
         /// <summary>
         /// Gets/sets the id of the OAuth2 client to use
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "clientId")]
-        [System.Text.Json.Serialization.JsonPropertyName("clientId")]
-        [YamlMember(Alias = "clientId")]
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual string ClientId { get; set; }
 
         /// <summary>
         /// Gets/sets the secret of the non-public OAuth2 client to use. Required when <see cref="GrantType"/> has been set to <see cref="OAuth2GrantType.TokenExchange"/>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "clientSecret")]
-        [System.Text.Json.Serialization.JsonPropertyName("clientSecret")]
-        [YamlMember(Alias = "clientSecret")]
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         public virtual string ClientSecret { get; set; }
 
         /// <summary>
         /// Gets/sets the username to use when authenticating
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "username")]
-        [System.Text.Json.Serialization.JsonPropertyName("username")]
-        [YamlMember(Alias = "username")]
+        [ProtoMember(5)]
+        [DataMember(Order = 5)]
         public virtual string Username { get; set; }
 
         /// <summary>
         /// Gets/sets the password to use when authenticating
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "password")]
-        [System.Text.Json.Serialization.JsonPropertyName("password")]
-        [YamlMember(Alias = "password")]
+        [ProtoMember(6)]
+        [DataMember(Order = 6)]
         public virtual string Password { get; set; }
 
         /// <summary>
         /// Gets/sets a <see cref="List{T}"/> containing the authorized scopes of the resulting token
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "scopes")]
-        [System.Text.Json.Serialization.JsonPropertyName("scopes")]
-        [YamlMember(Alias = "scopes")]
+        [ProtoMember(7)]
+        [DataMember(Order = 7)]
         public virtual List<string> Scopes { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets/sets a <see cref="List{T}"/> containing the authorized audiences of the resulting token
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "audiences")]
-        [System.Text.Json.Serialization.JsonPropertyName("audiences")]
-        [YamlMember(Alias = "audiences")]
+        [ProtoMember(8)]
+        [DataMember(Order = 8)]
         public virtual List<string> Audiences { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets/sets the token to exchange for Impersonation
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "subjectToken")]
-        [System.Text.Json.Serialization.JsonPropertyName("subjectToken")]
-        [YamlMember(Alias = "subjectToken")]
+        [ProtoMember(9)]
+        [DataMember(Order = 9)]
         public virtual string SubjectToken { get; set; }
 
         /// <summary>
         /// Gets/sets the requested subject for Impersonation and Direct Naked Impersonation, which can be the id or the username of the user to impersonate
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "requestedSubject")]
-        [System.Text.Json.Serialization.JsonPropertyName("requestedSubject")]
-        [YamlMember(Alias = "requestedSubject")]
+        [ProtoMember(10)]
+        [DataMember(Order = 10)]
         public virtual string RequestedSubject { get; set; }
 
         /// <summary>
         /// Gets/sets the issuer that must generate a new token in return for the exchanged one
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "requestedIssuer")]
-        [System.Text.Json.Serialization.JsonPropertyName("requestedIssuer")]
-        [YamlMember(Alias = "requestedIssuer")]
+        [ProtoMember(11)]
+        [DataMember(Order = 11)]
         public virtual string RequestedIssuer { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ODataCommandOptions.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ODataCommandOptions.cs
@@ -14,11 +14,6 @@
  * limitations under the License.
  *
  */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -26,17 +21,23 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents the options used to configure an OData command
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ODataCommandOptions
     {
 
         /// <summary>
         /// Gets the unique identifier of the single entry to query
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Key { get; set; }
 
         /// <summary>
         /// Gets the options used to configure the OData query
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual ODataQueryOptions QueryOptions { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ODataCommandOptions.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ODataCommandOptions.cs
@@ -32,7 +32,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets the unique identifier of the single entry to query
         /// </summary>
-        public virtual string Id { get; set; }
+        public virtual string Key { get; set; }
 
         /// <summary>
         /// Gets the options used to configure the OData query

--- a/src/ServerlessWorkflow.Sdk/Models/ODataCommandOptions.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ODataCommandOptions.cs
@@ -24,9 +24,9 @@ namespace ServerlessWorkflow.Sdk.Models
 {
 
     /// <summary>
-    /// Represents the options used to configure an OData operation call
+    /// Represents the options used to configure an OData command
     /// </summary>
-    public class ODataOperationOptions
+    public class ODataCommandOptions
     {
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Models/ODataQueryOptions.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ODataQueryOptions.cs
@@ -21,67 +21,93 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents the options used to configure an OData query
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ODataQueryOptions
     {
 
         /// <summary>
         /// Gets the $filter system query option, which allows clients to filter the set of resources that are addressed by a request URL. $filter specifies conditions that MUST be met by a resource for it to be returned in the set of matching resources
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Filter { get; set; }
 
         /// <summary>
         /// Gets the $expand system query option, which allows clients to request related resources when a resource that satifies a particular request is retrieved
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Expand { get; set; }
 
         /// <summary>
         /// Gets the $select system query option, which allows clients to requests a limited set of information for each entity or complex type identified by the ResourcePath and other System Query Options like $filter, $top, $skip etc. The $select query option is often used in conjunction with the $expand query option, to first increase the scope of the resource graph returned ($expand) and then selectively prune that resource graph ($select)
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual string Select { get; set; }
 
         /// <summary>
         /// Gets the $orderby system query option, which allows clients to request resource in a particular order
         /// </summary>
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         public virtual string OrderBy { get; set; }
 
         /// <summary>
         /// Gets the $top system query option, which allows clients a required number of resources. Usually used in conjunction with the $skip query options
         /// </summary>
+        [ProtoMember(5)]
+        [DataMember(Order = 5)]
         public virtual int? Top { get; set; }
 
         /// <summary>
         /// Gets the $skip system query option, which allows clients to skip a given number of resources. Usually used in conjunction with the $top query options
         /// </summary>
+        [ProtoMember(6)]
+        [DataMember(Order = 6)]
         public virtual int? Skip { get; set; }
 
         /// <summary>
         /// Gets the $count system query option, which allows clients to request a count of the matching resources included with the resources in the response
         /// </summary>
+        [ProtoMember(7)]
+        [DataMember(Order = 7)]
         public virtual bool Count { get; set; }
 
         /// <summary>
         /// Gets the $search system query option, which allows clients to request items within a collection matching a free-text search expression
         /// </summary>
+        [ProtoMember(8)]
+        [DataMember(Order = 8)]
         public virtual string Search { get; set; }
 
         /// <summary>
         /// Gets the $format system query option, if supported, which allows clients to request a response in a particular format
         /// </summary>
+        [ProtoMember(9)]
+        [DataMember(Order = 9)]
         public virtual string Format { get; set; }
 
         /// <summary>
         /// Gets the $compute system query option, which allows clients to define computed properties that can be used in a $select or within a $filter or $orderby expression
         /// </summary>
+        [ProtoMember(10)]
+        [DataMember(Order = 10)]
         public virtual string Compute { get; set; }
 
         /// <summary>
         /// Gets the $index system query option, which allows clients to do a positional insert into a collection annotated with using the Core.PositionalInsert term (see http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#VocCore)
         /// </summary>
+        [ProtoMember(11)]
+        [DataMember(Order = 11)]
         public virtual string Index { get; set; }
 
         /// <summary>
         /// Gets the $schemaversion system query option, which allows clients to specify the version of the schema against which the request is made. The semantics of $schemaversion is covered in the OData-Protocol (http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#odata) document
         /// </summary>
+        [ProtoMember(12)]
+        [DataMember(Order = 12)]
         public virtual string SchemaVersion { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/ODataQueryOptions.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ODataQueryOptions.cs
@@ -47,12 +47,12 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets the $top system query option, which allows clients a required number of resources. Usually used in conjunction with the $skip query options
         /// </summary>
-        public virtual int Top { get; set; }
+        public virtual int? Top { get; set; }
 
         /// <summary>
         /// Gets the $skip system query option, which allows clients to skip a given number of resources. Usually used in conjunction with the $top query options
         /// </summary>
-        public virtual int Skip { get; set; }
+        public virtual int? Skip { get; set; }
 
         /// <summary>
         /// Gets the $count system query option, which allows clients to request a count of the matching resources included with the resources in the response

--- a/src/ServerlessWorkflow.Sdk/Models/OneOf.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/OneOf.cs
@@ -1,0 +1,191 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Neuroglia.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace ServerlessWorkflow.Sdk.Models
+{
+
+    /// <summary>
+    /// Gets an object that is one of the specified types
+    /// </summary>
+    /// <typeparam name="T1">A first type alternative</typeparam>
+    /// <typeparam name="T2">A second type alternative</typeparam>
+    [ProtoContract]
+    [DataContract]
+    public class OneOf<T1, T2>
+        : IExtensible
+    {
+
+        private IExtension _Extension;
+        IExtension IExtensible.GetExtensionObject(bool createIfMissing) => Extensible.GetExtensionObject(ref this._Extension, createIfMissing);
+
+        private DiscriminatedUnionObject _DicriminatorUnionObject;
+
+        /// <summary>
+        /// Initializes a new <see cref="OneOf{T1, T2}"/>
+        /// </summary>
+        protected OneOf()
+        {
+            
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="OneOf{T1, T2}"/>
+        /// </summary>
+        /// <param name="value">The value of the <see cref="OneOf{T1, T2}"/></param>
+        public OneOf(T1 value)
+        {
+            this.Value1 = value;
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="OneOf{T1, T2}"/>
+        /// </summary>
+        /// <param name="value">The value of the <see cref="OneOf{T1, T2}"/></param>
+        public OneOf(T2 value)
+        {
+            this.Value2 = value;
+        }
+
+        /// <summary>
+        /// Gets the first possible value
+        /// </summary>
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [YamlDotNet.Serialization.YamlIgnore]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
+        public T1 Value1
+        {
+            get => _DicriminatorUnionObject.Is(1) ? ((T1)_DicriminatorUnionObject.Object) : default;
+            set => _DicriminatorUnionObject = new(1, value);
+        }
+
+        bool ShouldSerializeT1() => this._DicriminatorUnionObject.Is(1);
+
+        void ResetT1() => DiscriminatedUnionObject.Reset(ref this._DicriminatorUnionObject, 1);
+
+        /// <summary>
+        /// Gets the second possible value
+        /// </summary>
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [YamlDotNet.Serialization.YamlIgnore]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
+        public T2 Value2
+        {
+            get => _DicriminatorUnionObject.Is(2) ? ((T2)_DicriminatorUnionObject.Object) : default;
+            set => _DicriminatorUnionObject = new(2, value);
+        }
+
+        bool ShouldSerializeT2() => this._DicriminatorUnionObject.Is(2);
+
+        void ResetT2() => DiscriminatedUnionObject.Reset(ref this._DicriminatorUnionObject, 2);
+
+        /// <summary>
+        /// Implicitly convert the specified value into a new <see cref="OneOf{T1, T2}"/>
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        public static implicit operator OneOf<T1, T2>(T1 value)
+        {
+            return new(value);
+        }
+
+        /// <summary>
+        /// Implicitly convert the specified value into a new <see cref="OneOf{T1, T2}"/>
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        public static implicit operator OneOf<T1, T2>(T2 value)
+        {
+            return new(value);
+        }
+
+        /// <summary>
+        /// Implicitly convert the specified <see cref="OneOf{T1, T2}"/> into a new value
+        /// </summary>
+        /// <param name="value">The <see cref="OneOf{T1, T2}"/> to convert</param>
+        public static implicit operator T1(OneOf<T1, T2> value)
+        {
+            return value.Value1;
+        }
+
+        /// <summary>
+        /// Implicitly convert the specified <see cref="OneOf{T1, T2}"/> into a new value
+        /// </summary>
+        /// <param name="value">The <see cref="OneOf{T1, T2}"/> to convert</param>
+        public static implicit operator T2(OneOf<T1, T2> value)
+        {
+            return value.Value2;
+        }
+
+    }
+
+    /// <summary>
+    /// Represents an object of any type
+    /// </summary>
+    [ProtoContract]
+    [DataContract]
+    [Newtonsoft.Json.JsonConverter(typeof(Any))]
+    public class Any
+        : ProtoObject
+    {
+
+        /// <inheritdoc/>
+        [ProtoMember(1)]
+        protected new List<ProtoField> Fields
+        {
+            get => base.Fields;
+            set => base.Fields = value;
+        }
+
+    }
+
+    /// <summary>
+    /// Represents the <see cref="Newtonsoft.Json.JsonConverter"/> used to convert from and to <see cref="Any"/> instances
+    /// </summary>
+    public class AnyConverter
+        : Newtonsoft.Json.JsonConverter<Any>
+    {
+
+        /// <inheritdoc/>
+        public override Any ReadJson(JsonReader reader, Type objectType, Any existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var jobject = JObject.ReadFrom(reader);
+            var any = new Any();
+            foreach(var property in jobject)
+            {
+                any.Set(property.Name, property.Value<object>());
+            }
+            return any;
+        }
+
+        /// <inheritdoc/>
+        public override void WriteJson(JsonWriter writer, Any value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value.ToObject());
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Models/OneOf.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/OneOf.cs
@@ -146,10 +146,23 @@ namespace ServerlessWorkflow.Sdk.Models
     /// </summary>
     [ProtoContract]
     [DataContract]
-    [Newtonsoft.Json.JsonConverter(typeof(Any))]
+    [Newtonsoft.Json.JsonConverter(typeof(AnyConverter))]
     public class Any
         : ProtoObject
     {
+
+        public Any()
+        {
+
+        }
+
+        public Any(IDictionary<string, object> properties)
+        {
+            foreach (var property in properties)
+            {
+                this.Set(property.Key, property.Value);
+            }
+        }
 
         /// <inheritdoc/>
         [ProtoMember(1)]
@@ -171,9 +184,9 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <inheritdoc/>
         public override Any ReadJson(JsonReader reader, Type objectType, Any existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            var jobject = JObject.ReadFrom(reader);
+            var jobject = (JObject)JObject.ReadFrom(reader);
             var any = new Any();
-            foreach(var property in jobject)
+            foreach(var property in jobject.Properties())
             {
                 any.Set(property.Name, property.Value<object>());
             }

--- a/src/ServerlessWorkflow.Sdk/Models/OneOf.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/OneOf.cs
@@ -48,7 +48,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <param name="value">The value of the <see cref="OneOf{T1, T2}"/></param>
         public OneOf(T1 value)
         {
-            this.Value1 = value;
+            this.T1Value = value;
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <param name="value">The value of the <see cref="OneOf{T1, T2}"/></param>
         public OneOf(T2 value)
         {
-            this.Value2 = value;
+            this.T2Value = value;
         }
 
         /// <summary>
@@ -68,15 +68,15 @@ namespace ServerlessWorkflow.Sdk.Models
         [YamlDotNet.Serialization.YamlIgnore]
         [ProtoMember(1)]
         [DataMember(Order = 1)]
-        public T1 Value1
+        public T1 T1Value
         {
             get => _DicriminatorUnionObject.Is(1) ? ((T1)_DicriminatorUnionObject.Object) : default;
             set => _DicriminatorUnionObject = new(1, value);
         }
 
-        bool ShouldSerializeT1() => this._DicriminatorUnionObject.Is(1);
+        bool ShouldSerializeT1Value() => this._DicriminatorUnionObject.Is(1);
 
-        void ResetT1() => DiscriminatedUnionObject.Reset(ref this._DicriminatorUnionObject, 1);
+        void ResetT1Value() => DiscriminatedUnionObject.Reset(ref this._DicriminatorUnionObject, 1);
 
         /// <summary>
         /// Gets the second possible value
@@ -86,22 +86,22 @@ namespace ServerlessWorkflow.Sdk.Models
         [YamlDotNet.Serialization.YamlIgnore]
         [ProtoMember(2)]
         [DataMember(Order = 2)]
-        public T2 Value2
+        public T2 T2Value
         {
             get => _DicriminatorUnionObject.Is(2) ? ((T2)_DicriminatorUnionObject.Object) : default;
             set => _DicriminatorUnionObject = new(2, value);
         }
 
-        bool ShouldSerializeT2() => this._DicriminatorUnionObject.Is(2);
+        bool ShouldSerializeT2Value() => this._DicriminatorUnionObject.Is(2);
 
-        void ResetT2() => DiscriminatedUnionObject.Reset(ref this._DicriminatorUnionObject, 2);
+        void ResetT2Value() => DiscriminatedUnionObject.Reset(ref this._DicriminatorUnionObject, 2);
 
         object IOneOf.GetValue()
         {
-            if (this.Value1 == null)
-                return this.Value2;
+            if (this.T1Value == null)
+                return this.T2Value;
             else
-                return this.Value1;
+                return this.T1Value;
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <param name="value">The <see cref="OneOf{T1, T2}"/> to convert</param>
         public static implicit operator T1(OneOf<T1, T2> value)
         {
-            return value.Value1;
+            return value.T1Value;
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <param name="value">The <see cref="OneOf{T1, T2}"/> to convert</param>
         public static implicit operator T2(OneOf<T1, T2> value)
         {
-            return value.Value2;
+            return value.T2Value;
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/OneOf.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/OneOf.cs
@@ -14,13 +14,6 @@
  * limitations under the License.
  *
  */
-using Neuroglia.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using ProtoBuf;
-using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -33,7 +26,7 @@ namespace ServerlessWorkflow.Sdk.Models
     [ProtoContract]
     [DataContract]
     public class OneOf<T1, T2>
-        : IExtensible
+        : IExtensible, IOneOf
     {
 
         private IExtension _Extension;
@@ -103,6 +96,14 @@ namespace ServerlessWorkflow.Sdk.Models
 
         void ResetT2() => DiscriminatedUnionObject.Reset(ref this._DicriminatorUnionObject, 2);
 
+        object IOneOf.GetValue()
+        {
+            if (this.Value1 == null)
+                return this.Value2;
+            else
+                return this.Value1;
+        }
+
         /// <summary>
         /// Implicitly convert the specified value into a new <see cref="OneOf{T1, T2}"/>
         /// </summary>
@@ -137,66 +138,6 @@ namespace ServerlessWorkflow.Sdk.Models
         public static implicit operator T2(OneOf<T1, T2> value)
         {
             return value.Value2;
-        }
-
-    }
-
-    /// <summary>
-    /// Represents an object of any type
-    /// </summary>
-    [ProtoContract]
-    [DataContract]
-    [Newtonsoft.Json.JsonConverter(typeof(AnyConverter))]
-    public class Any
-        : ProtoObject
-    {
-
-        public Any()
-        {
-
-        }
-
-        public Any(IDictionary<string, object> properties)
-        {
-            foreach (var property in properties)
-            {
-                this.Set(property.Key, property.Value);
-            }
-        }
-
-        /// <inheritdoc/>
-        [ProtoMember(1)]
-        protected new List<ProtoField> Fields
-        {
-            get => base.Fields;
-            set => base.Fields = value;
-        }
-
-    }
-
-    /// <summary>
-    /// Represents the <see cref="Newtonsoft.Json.JsonConverter"/> used to convert from and to <see cref="Any"/> instances
-    /// </summary>
-    public class AnyConverter
-        : Newtonsoft.Json.JsonConverter<Any>
-    {
-
-        /// <inheritdoc/>
-        public override Any ReadJson(JsonReader reader, Type objectType, Any existingValue, bool hasExistingValue, JsonSerializer serializer)
-        {
-            var jobject = (JObject)JObject.ReadFrom(reader);
-            var any = new Any();
-            foreach(var property in jobject.Properties())
-            {
-                any.Set(property.Name, property.Value<object>());
-            }
-            return any;
-        }
-
-        /// <inheritdoc/>
-        public override void WriteJson(JsonWriter writer, Any value, JsonSerializer serializer)
-        {
-            serializer.Serialize(writer, value.ToObject());
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/OperationStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/OperationStateDefinition.cs
@@ -17,6 +17,7 @@
 using ServerlessWorkflow.Sdk.Serialization;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -49,6 +50,46 @@ namespace ServerlessWorkflow.Sdk.Models
         [Required]
         [Newtonsoft.Json.JsonRequired]
         public virtual List<ActionDefinition> Actions { get; set; } = new List<ActionDefinition>();
+
+        /// <summary>
+        /// Gets the <see cref="ActionDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="ActionDefinition"/> to get</param>
+        /// <returns>The <see cref="ActionDefinition"/> with the specified name</returns>
+        public virtual ActionDefinition GetAction(string name)
+        {
+            return this.Actions.FirstOrDefault(s => s.Name == name);
+        }
+
+        /// <summary>
+        /// Attempts to get the <see cref="ActionDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="ActionDefinition"/> to get</param>
+        /// <param name="action">The <see cref="ActionDefinition"/> with the specified name</param>
+        /// <returns>A boolean indicating whether or not a <see cref="ActionDefinition"/> with the specified name could be found</returns>
+        public virtual bool TryGetAction(string name, out ActionDefinition action)
+        {
+            action = this.GetAction(name);
+            return action != null;
+        }
+
+        /// <summary>
+        /// Attempts to get the next <see cref="ActionDefinition"/> in the pipeline
+        /// </summary>
+        /// <param name="previousActionName">The name of the <see cref="ActionDefinition"/> to get the next <see cref="ActionDefinition"/> for</param>
+        /// <param name="action">The next <see cref="ActionDefinition"/>, if any</param>
+        /// <returns>A boolean indicating whether or not there is a next <see cref="ActionDefinition"/> in the pipeline</returns>
+        public virtual bool TryGetNextAction(string previousActionName, out ActionDefinition action)
+        {
+            action = null;
+            ActionDefinition previousAction = this.Actions.FirstOrDefault(a => a.Name == previousActionName);
+            int previousActionIndex = this.Actions.ToList().IndexOf(previousAction);
+            int nextIndex = previousActionIndex + 1;
+            if (nextIndex >= this.Actions.Count)
+                return false;
+            action = this.Actions.ElementAt(nextIndex);
+            return true;
+        }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/OperationStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/OperationStateDefinition.cs
@@ -26,6 +26,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// Represents a workflow state that defines a set of actions to be performed in sequence or in parallel. Once all actions have been performed, a transition to another state can occur.
     /// </summary>
     [DiscriminatorValue(StateType.Operation)]
+    [ProtoContract]
+    [DataContract]
     public class OperationStateDefinition
         : StateDefinition
     {
@@ -42,6 +44,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets a value that specifies how actions are to be performed (in sequence of parallel). Defaults to sequential
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual ActionExecutionMode ActionMode { get; set; } = ActionExecutionMode.Sequential;
 
         /// <summary>
@@ -49,6 +53,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual List<ActionDefinition> Actions { get; set; } = new List<ActionDefinition>();
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Models/ParallelStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ParallelStateDefinition.cs
@@ -16,6 +16,7 @@
  */
 using ServerlessWorkflow.Sdk.Serialization;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -50,6 +51,28 @@ namespace ServerlessWorkflow.Sdk.Models
         /// Gets/sets a value that represents the amount of <see cref="BranchDefinition"/>es to complete for completing the state, when <see cref="CompletionType"/> is set to <see cref="ParallelCompletionType.N"/>
         /// </summary>
         public virtual uint? N { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="BranchDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="BranchDefinition"/> to get</param>
+        /// <returns>The <see cref="BranchDefinition"/> with the specified name</returns>
+        public virtual BranchDefinition GetBranch(string name)
+        {
+            return this.Branches.FirstOrDefault(b => b.Name == name);
+        }
+
+        /// <summary>
+        /// Attempts to get the <see cref="BranchDefinition"/> with the specified name
+        /// </summary>
+        /// <param name="name">The name of the <see cref="BranchDefinition"/> to get</param>
+        /// <param name="branch">The <see cref="BranchDefinition"/> with the specified name</param>
+        /// <returns>A boolean indicating whether or not a <see cref="BranchDefinition"/> with the specified name could be found</returns>
+        public virtual bool TryGetBranch(string name, out BranchDefinition branch)
+        {
+            branch = this.GetBranch(name);
+            return branch != null;
+        }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/ParallelStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ParallelStateDefinition.cs
@@ -24,6 +24,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// Represents a workflow state that executes <see cref="BranchDefinition"/>es in parallel
     /// </summary>
     [DiscriminatorValue(StateType.Parallel)]
+    [ProtoContract]
+    [DataContract]
     public class ParallelStateDefinition
         : StateDefinition
     {
@@ -40,16 +42,22 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets an <see cref="List{T}"/> containing the <see cref="BranchDefinition"/>es executed by the <see cref="ParallelStateDefinition"/>
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual List<BranchDefinition> Branches { get; set; } = new List<BranchDefinition>();
 
         /// <summary>
         /// Gets/sets a value that configures the way the <see cref="ParallelStateDefinition"/> completes. Defaults to 'And'
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual ParallelCompletionType CompletionType { get; set; } = ParallelCompletionType.And;
 
         /// <summary>
         /// Gets/sets a value that represents the amount of <see cref="BranchDefinition"/>es to complete for completing the state, when <see cref="CompletionType"/> is set to <see cref="ParallelCompletionType.N"/>
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual uint? N { get; set; }
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Models/ProduceEventDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ProduceEventDefinition.cs
@@ -14,13 +14,14 @@
  * limitations under the License.
  *
  */
-using Newtonsoft.Json.Linq;
 using System.ComponentModel.DataAnnotations;
 namespace ServerlessWorkflow.Sdk.Models
 {
     /// <summary>
     /// Represents the object used to configure an event o produce
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ProduceEventDefinition
     {
 
@@ -29,12 +30,16 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public string EventReference { get; set; }
 
         /// <summary>
         /// Gets/sets the data to pass to the cloud event to produce. If String, expression which selects parts of the states data output to become the data of the produced event. If object a custom object to become the data of produced event.
         /// </summary>
-        public JToken Data { get; set; }
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
+        public Any Data { get; set; }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/RetryStrategyDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/RetryStrategyDefinition.cs
@@ -17,14 +17,16 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 using System.Xml;
 using YamlDotNet.Serialization;
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents an object that defines workflow states retry policy strategy. This is an explicit definition and can be reused across multiple defined workflow state errors.
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class RetryStrategyDefinition
     {
 
@@ -33,11 +35,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Name { get; set; }
 
         /// <summary>
         /// Gets/sets delay between retry attempts
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.Iso8601TimeSpanConverter))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter))]
         public virtual TimeSpan? Delay { get; set; }
@@ -45,11 +51,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the maximum amount of retries allowed
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual uint? MaxAttempts { get; set; }
 
         /// <summary>
         /// Gets/sets the maximum delay between retries
         /// </summary>
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.Iso8601TimeSpanConverter))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter))]
         public virtual TimeSpan? MaxDelay { get; set; }
@@ -57,6 +67,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the duration which will be added to the delay between successive retries
         /// </summary>
+        [ProtoMember(5)]
+        [DataMember(Order = 5)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.Iso8601TimeSpanConverter))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter))]
         public virtual TimeSpan? Increment { get; set; }
@@ -65,6 +77,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// Gets/sets a value by which the delay is multiplied before each attempt. For example: "1.2" meaning that each successive delay is 20% longer than the previous delay. 
         /// For example, if delay is 'PT10S', then the delay between the first and second attempts will be 10 seconds, and the delay before the third attempt will be 12 seconds.
         /// </summary>
+        [ProtoMember(6)]
+        [DataMember(Order = 6)]
         public virtual float? Multiplier { get; set; }
 
         /// <summary>
@@ -73,7 +87,9 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "jitter")]
         [System.Text.Json.Serialization.JsonPropertyName("jitter")]
         [YamlMember(Alias = "jitter")]
-        protected virtual JToken JitterToken { get; set; }
+        [ProtoMember(7, Name = "jitter")]
+        [DataMember(Order = 7, Name = "jitter")]
+        protected virtual OneOf<float?, string> JitterToken { get; set; }
 
         /// <summary>
         /// Gets/sets the maximum amount of random time added or subtracted from the delay between each retry relative to total delay
@@ -82,10 +98,7 @@ namespace ServerlessWorkflow.Sdk.Models
         {
             get
             {
-                if (this.JitterToken?.Type != JTokenType.Float
-                    || (this.JitterToken?.Type == JTokenType.String && !float.TryParse(this.JitterToken.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out _)))
-                    return null;
-                return this.JitterToken.ToObject<float>();
+                return this.JitterToken?.Value1;
             }
             set
             {
@@ -94,7 +107,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     this.JitterToken = null;
                     return;
                 }
-                this.JitterToken = JToken.FromObject(value);
+                this.JitterToken = new(value);
             }
         }
 
@@ -105,10 +118,10 @@ namespace ServerlessWorkflow.Sdk.Models
         {
             get
             {
-                if (this.JitterToken?.Type != JTokenType.String
-                    || float.TryParse(this.JitterToken.Value<string>(), NumberStyles.Any, CultureInfo.InvariantCulture, out _))
+                if (this.JitterToken == null
+                    || string.IsNullOrWhiteSpace(this.JitterToken.Value2))
                     return null;
-                return XmlConvert.ToTimeSpan(this.JitterToken.ToString());
+                return XmlConvert.ToTimeSpan(this.JitterToken.Value2);
             }
             set
             {
@@ -117,7 +130,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     this.JitterToken = null;
                     return;
                 }
-                this.JitterToken = XmlConvert.ToString(value.Value);
+                this.JitterToken = new(XmlConvert.ToString(value.Value));
             }
         }
 

--- a/src/ServerlessWorkflow.Sdk/Models/RetryStrategyDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/RetryStrategyDefinition.cs
@@ -98,7 +98,7 @@ namespace ServerlessWorkflow.Sdk.Models
         {
             get
             {
-                return this.JitterToken?.Value1;
+                return this.JitterToken?.T1Value;
             }
             set
             {
@@ -119,9 +119,9 @@ namespace ServerlessWorkflow.Sdk.Models
             get
             {
                 if (this.JitterToken == null
-                    || string.IsNullOrWhiteSpace(this.JitterToken.Value2))
+                    || string.IsNullOrWhiteSpace(this.JitterToken.T2Value))
                     return null;
-                return XmlConvert.ToTimeSpan(this.JitterToken.Value2);
+                return XmlConvert.ToTimeSpan(this.JitterToken.T2Value);
             }
             set
             {

--- a/src/ServerlessWorkflow.Sdk/Models/ScheduleDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ScheduleDefinition.cs
@@ -63,10 +63,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Cron == null
                    && this.CronToken != null)
                 {
-                    if (this.CronToken.Value1 == null)
-                        this._Cron = new() { Expression = this.CronToken.Value2 };
+                    if (this.CronToken.T1Value == null)
+                        this._Cron = new() { Expression = this.CronToken.T2Value };
                     else
-                        this._Cron = this.CronToken.Value1;
+                        this._Cron = this.CronToken.T1Value;
                 }
                 return this._Cron;
             }

--- a/src/ServerlessWorkflow.Sdk/Models/ScheduleDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ScheduleDefinition.cs
@@ -23,12 +23,16 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to define the time/repeating intervals at which workflow instances can/should be started 
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class ScheduleDefinition
     {
 
         /// <summary>
         /// Gets/sets the time interval (ISO 8601 format) describing when workflow instances can be created.
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Interval { get; set; }
 
         /// <summary>
@@ -37,7 +41,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "cron")]
         [System.Text.Json.Serialization.JsonPropertyName("cron")]
         [YamlMember(Alias = "cron")]
-        public virtual JToken CronToken { get; set; }
+        [ProtoMember(2, Name = "cron")]
+        [DataMember(Order = 2, Name = "cron")]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<CronDefinition, string>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<CronDefinition, string>))]
+        public virtual OneOf<CronDefinition, string> CronToken { get; set; }
 
         private CronDefinition _Cron;
         /// <summary>
@@ -46,6 +54,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual CronDefinition Cron
         {
             get
@@ -53,10 +63,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Cron == null
                    && this.CronToken != null)
                 {
-                    if (this.CronToken.Type == JTokenType.String)
-                        this._Cron = new CronDefinition() { Expression = this.CronToken.ToObject<string>() };
+                    if (this.CronToken.Value1 == null)
+                        this._Cron = new() { Expression = this.CronToken.Value2 };
                     else
-                        this._Cron = this.CronToken.ToObject<CronDefinition>();
+                        this._Cron = this.CronToken.Value1;
                 }
                 return this._Cron;
             }
@@ -69,24 +79,15 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Cron = value;
-                this.CronToken = JToken.FromObject(value);
+                this.CronToken = new(value);
             }
         }
 
         /// <summary>
-        /// Gets/sets a boolean indicating whether or not workflow instances can be created outside of the defined interval/cron. Defaults to false.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "directInvoke")]
-        [System.Text.Json.Serialization.JsonPropertyName("directInvoke")]
-        [YamlMember(Alias = "directInvoke")]
-        public virtual bool DirectInvoke { get; set; } = false;
-
-        /// <summary>
         /// Gets/sets the timezone name used to evaluate the cron expression. Not used for interval as timezone can be specified there directly. If not specified, should default to local machine timezone.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "timezone")]
-        [System.Text.Json.Serialization.JsonPropertyName("timezone")]
-        [YamlMember(Alias = "timezone")]
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual string Timezone { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/SecretBasedAuthenticationProperties.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/SecretBasedAuthenticationProperties.cs
@@ -19,9 +19,12 @@ using System;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents <see cref="AuthenticationProperties"/> loaded from a specific secret
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class SecretBasedAuthenticationProperties
         : AuthenticationProperties
     {
@@ -48,6 +51,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets the name of the secret to load the <see cref="SecretBasedAuthenticationProperties"/> from
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Secret { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/SleepStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/SleepStateDefinition.cs
@@ -20,19 +20,22 @@ using YamlDotNet.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents a workflow state that waits for a certain amount of time before transitioning to a next state
     /// </summary>
-    [DiscriminatorValue(StateType.Delay)]
-    public class DelayStateDefinition
+    [DiscriminatorValue(StateType.Sleep)]
+    [ProtoContract]
+    [DataContract]
+    public class SleepStateDefinition
        : StateDefinition
     {
 
         /// <summary>
-        /// Initializes a new <see cref="DelayStateDefinition"/>
+        /// Initializes a new <see cref="SleepStateDefinition"/>
         /// </summary>
-        public DelayStateDefinition()
-            : base(StateType.Delay)
+        public SleepStateDefinition()
+            : base(StateType.Sleep)
         {
 
         }
@@ -43,6 +46,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "timeDelay"), Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.Iso8601TimeSpanConverter))]
         [System.Text.Json.Serialization.JsonPropertyName("timeDelay"), System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter))]
         [YamlMember(Alias = "timeDelay")]
+        [ProtoMember(1, Name = "timeDelay")]
+        [DataMember(Order = 1, Name = "timeDelay")]
         public virtual TimeSpan Delay { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/StartDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StartDefinition.cs
@@ -28,7 +28,7 @@ namespace ServerlessWorkflow.Sdk.Models
     {
 
         /// <summary>
-        /// Gets/sets the name of the <see cref="WorkflowDefinition"/>'s start <see cref="StateDefinition"/>
+        /// Gets/sets the name of the <see cref="WorkflowDefinition"/>'s start <see cref="StateDefinition"/>. If not defined, defaults to the first defined state
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]

--- a/src/ServerlessWorkflow.Sdk/Models/StartDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StartDefinition.cs
@@ -15,7 +15,6 @@
  *
  */
 using System.ComponentModel.DataAnnotations;
-using YamlDotNet.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
@@ -23,6 +22,8 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents an object used to explicitly define how/when workflow instances should be created
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class StartDefinition
     {
 
@@ -30,9 +31,9 @@ namespace ServerlessWorkflow.Sdk.Models
         /// Gets/sets the name of the <see cref="WorkflowDefinition"/>'s start <see cref="StateDefinition"/>
         /// </summary>
         [Required]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stateName")]
-        [System.Text.Json.Serialization.JsonPropertyName("stateName")]
-        [YamlMember(Alias = "stateName")]
+        [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string StateName { get; set; }
 
         /// <summary>
@@ -40,10 +41,9 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "schedule")]
-        [System.Text.Json.Serialization.JsonPropertyName("schedule")]
-        [YamlMember(Alias = "schedule")]
-        public virtual ScheduleDefinition Schedule { get; set; } = new ScheduleDefinition();
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
+        public virtual ScheduleDefinition Schedule { get; set; } = new();
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/StateDataFilter.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateDataFilter.cs
@@ -14,30 +14,30 @@
  * limitations under the License.
  *
  */
-using YamlDotNet.Serialization;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents the object used to configure how to filter the states data input and output
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class StateDataFilter
     {
 
         /// <summary>
         /// Gets/sets an expression to filter the states data input
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "input")]
-        [System.Text.Json.Serialization.JsonPropertyName("input")]
-        [YamlMember(Alias = "input")]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Input { get; set; }
 
         /// <summary>
         /// Gets/sets an expression that filters the states data output
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "output")]
-        [System.Text.Json.Serialization.JsonPropertyName("output")]
-        [YamlMember(Alias = "output")]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Output { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/StateDataFilterDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateDataFilterDefinition.cs
@@ -16,20 +16,27 @@
  */
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents the object used to configure how to filter the states data input and output
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class StateDataFilterDefinition
     {
 
         /// <summary>
         /// Gets/sets an expression to filter the states data input
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Input { get; set; }
 
         /// <summary>
         /// Gets/sets an expression that filters the states data output
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Output { get; set; }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
@@ -76,52 +76,13 @@ namespace ServerlessWorkflow.Sdk.Models
         public virtual string Name { get; set; }
 
         /// <summary>
-        /// Gets/sets the <see cref="JToken"/> that represents the <see cref="StateDefinition"/>'s <see cref="EndDefinition"/>
+        /// Gets/sets the <see cref="OneOf{T1, T2}"/> that represents the <see cref="StateDefinition"/>'s <see cref="EndDefinition"/>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
-        [System.Text.Json.Serialization.JsonPropertyName("end")]
-        [YamlMember(Alias = "end")]
-        [ProtoMember(4, Name = "end")]
-        [DataMember(Order = 4, Name = "end")]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<bool, EndDefinition>))]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<bool, EndDefinition>))]
-        protected virtual OneOf<bool, EndDefinition> EndToken { get; set; }
-
-        private EndDefinition _End;
-        /// <summary>
-        /// Gets/sets the <see cref="StateDefinition"/>'s <see cref="EndDefinition"/>
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual EndDefinition End
-        {
-            get
-            {
-                if (this._End == null
-                    && this.EndToken != null)
-                {
-                    if (this.EndToken.Value2 == null)
-                        this._End = new EndDefinition();
-                    else
-                        this._End = this.EndToken.Value2;
-                }
-                return this._End;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    this._End = null;
-                    this.EndToken = null;
-                    return;
-                }
-                this._End = value;
-                this.EndToken = new(value);
-            }
-        }
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<EndDefinition, bool>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<EndDefinition, bool>))]
+        public virtual OneOf<EndDefinition, bool> End { get; set; }
 
         /// <summary>
         /// Gets/sets the filter to apply to the <see cref="StateDefinition"/>'s input and output data
@@ -144,52 +105,13 @@ namespace ServerlessWorkflow.Sdk.Models
         public virtual List<ErrorHandlerDefinition> Errors { get; set; } = new List<ErrorHandlerDefinition>();
 
         /// <summary>
-        /// Gets/sets the <see cref="JToken"/> that represents the <see cref="StateDefinition"/>'s <see cref="TransitionDefinition"/>
+        /// Gets/sets the <see cref="OneOf{T1, T2}"/> that represents the <see cref="StateDefinition"/>'s <see cref="TransitionDefinition"/>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "transition")]
-        [System.Text.Json.Serialization.JsonPropertyName("transition")]
-        [YamlMember(Alias = "transition")]
-        [ProtoMember(7, Name = "transition")]
-        [DataMember(Order = 7, Name = "transition")]
+        [ProtoMember(7)]
+        [DataMember(Order = 7)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<TransitionDefinition, string>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<TransitionDefinition, string>))]
-        protected virtual OneOf<TransitionDefinition, string> TransitionToken { get; set; }
-
-        private TransitionDefinition _Transition;
-        /// <summary>
-        /// Gets/sets the <see cref="StateDefinition"/>'s <see cref="TransitionDefinition"/>
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual TransitionDefinition Transition
-        {
-            get
-            {
-                if (this._Transition == null
-                    && this.TransitionToken != null)
-                {
-                    if (this.TransitionToken.Value1 == null)
-                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.Value2 };
-                    else
-                        this._Transition = this.TransitionToken.Value1;
-                }
-                return this._Transition;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    this._Transition = null;
-                    this.TransitionToken = null;
-                    return;
-                }
-                this._Transition = value;
-                this.TransitionToken = new(value);
-            }
-        }
+        public virtual OneOf<TransitionDefinition, string> Transition { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="JToken"/> that represents the <see cref="StateDefinition"/>'s <see cref="EndDefinition"/>

--- a/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
@@ -210,7 +210,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the <see cref="StateDefinition"/>'s metadata
         /// </summary>
-        public virtual JObject Metadata { get; set; } = new JObject();
+        public virtual Any Metadata { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
@@ -141,10 +141,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._DataInputSchema == null
                     && this.DataInputSchemaToken != null)
                 {
-                    if (this.DataInputSchemaToken.Value1 == null)
-                        this._DataInputSchema = new DataInputSchemaDefinition() { Schema = this.DataInputSchemaToken.Value2 };
+                    if (this.DataInputSchemaToken.T1Value == null)
+                        this._DataInputSchema = new DataInputSchemaDefinition() { Schema = this.DataInputSchemaToken.T2Value };
                     else
-                        this._DataInputSchema = this.DataInputSchemaToken.Value1;
+                        this._DataInputSchema = this.DataInputSchemaToken.T1Value;
                 }
                 return this._DataInputSchema;
             }

--- a/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
@@ -65,7 +65,9 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
         [System.Text.Json.Serialization.JsonPropertyName("end")]
         [YamlMember(Alias = "end")]
-        protected virtual JToken EndToken { get; set; }
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<bool, EndDefinition>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<bool, EndDefinition>))]
+        protected virtual OneOf<bool, EndDefinition> EndToken { get; set; }
 
         private EndDefinition _End;
         /// <summary>
@@ -81,11 +83,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._End == null
                     && this.EndToken != null)
                 {
-                    if (this.EndToken.Type == JTokenType.Boolean || this.EndToken.Type == JTokenType.String
-                        && this.EndToken.ToObject<bool>())
+                    if (this.EndToken.Value2 == null)
                         this._End = new EndDefinition();
                     else
-                        this._End = this.EndToken.ToObject<EndDefinition>();
+                        this._End = this.EndToken.Value2;
                 }
                 return this._End;
             }
@@ -98,7 +99,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._End = value;
-                this.EndToken = JToken.FromObject(value);
+                this.EndToken = new(value);
             }
         }
 
@@ -179,7 +180,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     if (this.DataInputSchemaToken.Type == JTokenType.String)
                         this._DataInputSchema = new DataInputSchemaDefinition() { Schema = this.DataInputSchemaToken.Value<string>() };
                     else
-                        this._DataInputSchema = this.EndToken.ToObject<DataInputSchemaDefinition>();
+                        this._DataInputSchema = this.DataInputSchemaToken.ToObject<DataInputSchemaDefinition>();
                 }
                 return this._DataInputSchema;
             }
@@ -204,7 +205,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets a boolean indicating whether or not the <see cref="StateDefinition"/> is used for compensating another <see cref="StateDefinition"/>
         /// </summary>
-        public virtual bool UseForCompensation { get; set; }
+        public virtual bool UsedForCompensation { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="StateDefinition"/>'s metadata

--- a/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateDefinition.cs
@@ -29,6 +29,16 @@ namespace ServerlessWorkflow.Sdk.Models
     [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.AbstractClassConverterFactory))]
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.AbstractClassConverterFactory))]
     [Discriminator(nameof(Type))]
+    [ProtoContract]
+    [ProtoInclude(100, typeof(CallbackStateDefinition))]
+    [ProtoInclude(200, typeof(SleepStateDefinition))]
+    [ProtoInclude(300, typeof(EventStateDefinition))]
+    [ProtoInclude(400, typeof(ForEachStateDefinition))]
+    [ProtoInclude(500, typeof(InjectStateDefinition))]
+    [ProtoInclude(600, typeof(OperationStateDefinition))]
+    [ProtoInclude(700, typeof(ParallelStateDefinition))]
+    [ProtoInclude(800, typeof(SwitchStateDefinition))]
+    [DataContract]
     public abstract class StateDefinition
     {
 
@@ -45,11 +55,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// Gets the <see cref="StateDefinition"/>'s type
         /// </summary>
         [YamlMember]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual StateType Type { get; protected set; }
 
         /// <summary>
         /// Gets/sets the <see cref="StateDefinition"/>'s id
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Id { get; set; }
 
         /// <summary>
@@ -57,6 +71,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Required]
         [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual string Name { get; set; }
 
         /// <summary>
@@ -65,6 +81,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
         [System.Text.Json.Serialization.JsonPropertyName("end")]
         [YamlMember(Alias = "end")]
+        [ProtoMember(4, Name = "end")]
+        [DataMember(Order = 4, Name = "end")]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<bool, EndDefinition>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<bool, EndDefinition>))]
         protected virtual OneOf<bool, EndDefinition> EndToken { get; set; }
@@ -76,6 +94,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual EndDefinition End
         {
             get
@@ -109,6 +129,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "stateDataFilter")]
         [System.Text.Json.Serialization.JsonPropertyName("stateDataFilter")]
         [YamlMember(Alias = "stateDataFilter")]
+        [ProtoMember(5, Name = "stateDataFilter")]
+        [DataMember(Order = 5, Name = "stateDataFilter")]
         public virtual StateDataFilterDefinition DataFilter { get; set; }
 
         /// <summary>
@@ -117,6 +139,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "onErrors")]
         [System.Text.Json.Serialization.JsonPropertyName("onErrors")]
         [YamlMember(Alias = "onErrors")]
+        [ProtoMember(6, Name = "onErrors")]
+        [DataMember(Order = 6, Name = "onErrors")]
         public virtual List<ErrorHandlerDefinition> Errors { get; set; } = new List<ErrorHandlerDefinition>();
 
         /// <summary>
@@ -125,7 +149,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "transition")]
         [System.Text.Json.Serialization.JsonPropertyName("transition")]
         [YamlMember(Alias = "transition")]
-        protected virtual JToken TransitionToken { get; set; }
+        [ProtoMember(7, Name = "transition")]
+        [DataMember(Order = 7, Name = "transition")]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<TransitionDefinition, string>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<TransitionDefinition, string>))]
+        protected virtual OneOf<TransitionDefinition, string> TransitionToken { get; set; }
 
         private TransitionDefinition _Transition;
         /// <summary>
@@ -134,6 +162,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual TransitionDefinition Transition
         {
             get
@@ -141,17 +171,23 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Transition == null
                     && this.TransitionToken != null)
                 {
-                    if (this.TransitionToken.Type == JTokenType.String)
-                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.ToString() };
+                    if (this.TransitionToken.Value1 == null)
+                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.Value2 };
                     else
-                        this._Transition = this.TransitionToken.ToObject<TransitionDefinition>();
+                        this._Transition = this.TransitionToken.Value1;
                 }
                 return this._Transition;
             }
             set
             {
-                this._Transition = value ?? throw new ArgumentNullException(nameof(value));
-                this.TransitionToken = JToken.FromObject(value);
+                if (value == null)
+                {
+                    this._Transition = null;
+                    this.TransitionToken = null;
+                    return;
+                }
+                this._Transition = value;
+                this.TransitionToken = new(value);
             }
         }
 
@@ -161,7 +197,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = nameof(DataInputSchema))]
         [System.Text.Json.Serialization.JsonPropertyName(nameof(DataInputSchema))]
         [YamlMember(Alias = nameof(DataInputSchema))]
-        protected virtual JToken DataInputSchemaToken { get; set; }
+        [ProtoMember(8, Name = nameof(DataInputSchema))]
+        [DataMember(Order = 8, Name = nameof(DataInputSchema))]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<DataInputSchemaDefinition, string>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<DataInputSchemaDefinition, string>))]
+        protected virtual OneOf<DataInputSchemaDefinition, string> DataInputSchemaToken { get; set; }
 
         private DataInputSchemaDefinition _DataInputSchema;
         /// <summary>
@@ -170,6 +210,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual DataInputSchemaDefinition DataInputSchema
         {
             get
@@ -177,10 +219,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._DataInputSchema == null
                     && this.DataInputSchemaToken != null)
                 {
-                    if (this.DataInputSchemaToken.Type == JTokenType.String)
-                        this._DataInputSchema = new DataInputSchemaDefinition() { Schema = this.DataInputSchemaToken.Value<string>() };
+                    if (this.DataInputSchemaToken.Value1 == null)
+                        this._DataInputSchema = new DataInputSchemaDefinition() { Schema = this.DataInputSchemaToken.Value2 };
                     else
-                        this._DataInputSchema = this.DataInputSchemaToken.ToObject<DataInputSchemaDefinition>();
+                        this._DataInputSchema = this.DataInputSchemaToken.Value1;
                 }
                 return this._DataInputSchema;
             }
@@ -193,23 +235,29 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._DataInputSchema = value;
-                this.DataInputSchemaToken = JToken.FromObject(value);
+                this.DataInputSchemaToken = new(value);
             }
         }
 
         /// <summary>
         /// Gets/sets the id of the <see cref="StateDefinition"/> used to compensate the <see cref="StateDefinition"/>
         /// </summary>
+        [ProtoMember(9)]
+        [DataMember(Order = 9)]
         public virtual string CompensatedBy { get; set; }
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not the <see cref="StateDefinition"/> is used for compensating another <see cref="StateDefinition"/>
         /// </summary>
+        [ProtoMember(10)]
+        [DataMember(Order = 10)]
         public virtual bool UsedForCompensation { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="StateDefinition"/>'s metadata
         /// </summary>
+        [ProtoMember(11)]
+        [DataMember(Order = 11)]
         public virtual Any Metadata { get; set; }
 
         /// <inheritdoc/>

--- a/src/ServerlessWorkflow.Sdk/Models/StateOutcomeDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/StateOutcomeDefinition.cs
@@ -21,6 +21,10 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents the base class for all <see cref="StateDefinition"/>'s outcomes
     /// </summary>
+    [ProtoContract]
+    [DataContract]
+    [ProtoInclude(100, typeof(EndDefinition))]
+    [ProtoInclude(200, typeof(TransitionDefinition))]
     public abstract class StateOutcomeDefinition
     {
 

--- a/src/ServerlessWorkflow.Sdk/Models/SubFlowLoopDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/SubFlowLoopDefinition.cs
@@ -24,33 +24,45 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents the definition of a subflow's loop
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class SubFlowLoopDefinition
     {
 
         /// <summary>
         /// Gets/sets the expression evaluated against subflow data. Subflow will repeat execution as long as this expression is true or until the max property count is reached
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Expression { get; set; }
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to perform a check before looping. If true, the expression is evaluated before each repeat execution, if false the expression is evaluated after each repeat execution. Defaults to True.
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual bool CheckBefore { get; set; } = true;
 
         /// <summary>
         /// Gets/sets the maximum amount of repeat executions
         /// </summary>
         [Range(0, int.MaxValue)]
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual int? Max { get; set; }
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to continue on error. If true, repeats executions in a case unhandled errors propagate from the sub-workflow to this state. Defaults to false.
         /// </summary>
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         public virtual bool ContinueOnError { get; set; } = false;
 
         /// <summary>
         /// Gets a <see cref="List{T}"/> containing the names of all the <see cref="EventDefinition"/>s to stop looping upon consumption of
         /// </summary>
+        [ProtoMember(5)]
+        [DataMember(Order = 5)]
         public virtual List<string> StopOnEvents { get; set; } = new List<string>();
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/SubflowReference.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/SubflowReference.cs
@@ -21,9 +21,12 @@ using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents a reference to a sub <see cref="WorkflowDefinition"/>
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class SubflowReference
     {
 
@@ -66,25 +69,23 @@ namespace ServerlessWorkflow.Sdk.Models
         /// Gets/sets the id of the <see cref="WorkflowDefinition"/> to run
         /// </summary>
         [Required]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "workflowId"), Newtonsoft.Json.JsonRequired]
-        [System.Text.Json.Serialization.JsonPropertyName("workflowId")]
-        [YamlMember(Alias = "workflowId")]
+        [Newtonsoft.Json.JsonRequired]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string WorkflowId { get; set; }
 
         /// <summary>
         /// Gets/sets the version of the <see cref="WorkflowDefinition"/> to run. Defaults to 'latest'
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "version")]
-        [System.Text.Json.Serialization.JsonPropertyName("version")]
-        [YamlMember(Alias = "version")]
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Version { get; set; } = "latest";
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to wait for the completion of the <see cref="WorkflowDefinition"/> to run. Defaults to true
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "waitForCompletion")]
-        [System.Text.Json.Serialization.JsonPropertyName("waitForCompletion")]
-        [YamlMember(Alias = "waitForCompletion")]
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual bool WaitForCompletion { get; set; } = true;
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Models/SwitchCaseDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/SwitchCaseDefinition.cs
@@ -61,97 +61,20 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the <see cref="JToken"/> that represents the <see cref="SwitchCaseDefinition"/>'s <see cref="TransitionDefinition"/>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "transition")]
-        [System.Text.Json.Serialization.JsonPropertyName("transition")]
-        [YamlMember(Alias = "transition")]
         [ProtoMember(2)]
         [DataMember(Order = 2)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<TransitionDefinition, string>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<TransitionDefinition, string>))]
-        protected virtual OneOf<TransitionDefinition, string> TransitionToken { get; set; }
-
-        private TransitionDefinition _Transition;
-        /// <summary>
-        /// Gets/sets the <see cref="TransitionDefinition"/> that should be performed when the condition is met
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual TransitionDefinition Transition
-        {
-            get
-            {
-                if (this._Transition == null
-                    && this.TransitionToken != null)
-                {
-                    if (this.TransitionToken.Value1 == null)
-                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.Value2 };
-                    else
-                        this._Transition = this.TransitionToken.Value1;
-                }
-                return this._Transition;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    this._Transition = null;
-                    this.TransitionToken = null;
-                    return;
-                }
-                this._Transition = value;
-                this.TransitionToken = new(value);
-            }
-        }
+        public virtual OneOf<TransitionDefinition, string> Transition { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="JToken"/> that represents the <see cref="SwitchCaseDefinition"/>'s <see cref="EndDefinition"/>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
-        [System.Text.Json.Serialization.JsonPropertyName("end")]
-        [YamlMember(Alias = "end")]
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<EndDefinition, bool>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<EndDefinition, bool>))]
-        protected virtual OneOf<EndDefinition, bool> EndToken { get; set; }
-
-        private EndDefinition _End;
-        /// <summary>
-        /// Gets/sets the <see cref="EndDefinition"/> that should be performed when the condition is met
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual EndDefinition End
-        {
-            get
-            {
-                if (this._End == null
-                    && this.EndToken != null)
-                {
-                    if (this.EndToken.Value1 == null
-                        && this.EndToken.Value2)
-                        this._End = new();
-                    else
-                        this._End = this.EndToken.Value1;
-                }
-                return this._End;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    this._End = null;
-                    this.EndToken = null;
-                    return;
-                }
-                this._End = value;
-                this.EndToken = new(value);
-            }
-        }
+        public virtual OneOf<EndDefinition, bool> End { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/ServerlessWorkflow.Sdk/Models/SwitchCaseDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/SwitchCaseDefinition.cs
@@ -25,6 +25,10 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents the base class for all <see cref="SwitchStateDefinition"/> case implementations
     /// </summary>
+    [ProtoContract]
+    [DataContract]
+    [ProtoInclude(100, typeof(DataCaseDefinition))]
+    [ProtoInclude(200, typeof(EventCaseDefinition))]
     public abstract class SwitchCaseDefinition
     {
 
@@ -34,6 +38,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public ConditionType Type
         {
             get
@@ -48,6 +54,8 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the <see cref="SwitchCaseDefinition"/>'s name
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Name { get; set; }
 
         /// <summary>
@@ -56,7 +64,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "transition")]
         [System.Text.Json.Serialization.JsonPropertyName("transition")]
         [YamlMember(Alias = "transition")]
-        protected virtual JToken TransitionToken { get; set; }
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<TransitionDefinition, string>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<TransitionDefinition, string>))]
+        protected virtual OneOf<TransitionDefinition, string> TransitionToken { get; set; }
 
         private TransitionDefinition _Transition;
         /// <summary>
@@ -65,6 +77,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual TransitionDefinition Transition
         {
             get
@@ -72,17 +86,23 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Transition == null
                     && this.TransitionToken != null)
                 {
-                    if (this.TransitionToken.Type == JTokenType.String)
-                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.ToString() };
+                    if (this.TransitionToken.Value1 == null)
+                        this._Transition = new TransitionDefinition() { To = this.TransitionToken.Value2 };
                     else
-                        this._Transition = this.TransitionToken.ToObject<TransitionDefinition>();
+                        this._Transition = this.TransitionToken.Value1;
                 }
                 return this._Transition;
             }
             set
             {
-                this._Transition = value ?? throw new ArgumentNullException(nameof(value));
-                this.TransitionToken = JToken.FromObject(value);
+                if (value == null)
+                {
+                    this._Transition = null;
+                    this.TransitionToken = null;
+                    return;
+                }
+                this._Transition = value;
+                this.TransitionToken = new(value);
             }
         }
 
@@ -92,7 +112,9 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
         [System.Text.Json.Serialization.JsonPropertyName("end")]
         [YamlMember(Alias = "end")]
-        protected virtual JToken EndToken { get; set; }
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<EndDefinition, bool>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<EndDefinition, bool>))]
+        protected virtual OneOf<EndDefinition, bool> EndToken { get; set; }
 
         private EndDefinition _End;
         /// <summary>
@@ -101,6 +123,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
         public virtual EndDefinition End
         {
             get
@@ -108,11 +132,11 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._End == null
                     && this.EndToken != null)
                 {
-                    if (this.EndToken.Type == JTokenType.Boolean || this.EndToken.Type == JTokenType.String
-                        && this.EndToken.ToObject<bool>())
-                        this._End = new EndDefinition();
+                    if (this.EndToken.Value1 == null
+                        && this.EndToken.Value2)
+                        this._End = new();
                     else
-                        this._End = this.EndToken.ToObject<EndDefinition>();
+                        this._End = this.EndToken.Value1;
                 }
                 return this._End;
             }
@@ -125,7 +149,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._End = value;
-                this.EndToken = JToken.FromObject(value);
+                this.EndToken = new(value);
             }
         }
 

--- a/src/ServerlessWorkflow.Sdk/Models/SwitchStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/SwitchStateDefinition.cs
@@ -72,7 +72,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets an object used to configure the <see cref="SwitchStateDefinition"/>'s default condition, in case none of the specified conditions were met
         /// </summary>
-        public virtual DefaultDefinition DefaultCondition { get; set; }
+        public virtual DefaultConditionDefinition DefaultCondition { get; set; }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Models/TransitionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/TransitionDefinition.cs
@@ -19,9 +19,12 @@ using System.ComponentModel.DataAnnotations;
 using YamlDotNet.Serialization;
 namespace ServerlessWorkflow.Sdk.Models
 {
+
     /// <summary>
     /// Represents an object used to define a state transition
     /// </summary>
+    [ProtoContract]
+    [DataContract]
     public class TransitionDefinition
         : StateOutcomeDefinition
     {
@@ -33,16 +36,22 @@ namespace ServerlessWorkflow.Sdk.Models
         [System.Text.Json.Serialization.JsonPropertyName("nextState")]
         [YamlMember(Alias = "nextState")]
         [Required]
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string To { get; set; }
 
         /// <summary>
         /// Gets/sets an <see cref="IEnumerable{T}"/> containing the events to be produced before the transition happens
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual IEnumerable<ProduceEventDefinition> ProduceEvents { get; set; } = new List<ProduceEventDefinition>();
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to trigger workflow compensation before the transition is taken. Default is false
         /// </summary>
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual bool Compensate { get; set; } = false;
 
     }

--- a/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
@@ -243,7 +243,7 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [ProtoMember(13)]
         [DataMember(Order = 13)]
-        public virtual JObject Metadata { get; set; } = new JObject();
+        public virtual Any Metadata { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="JToken"/> that represents the <see cref="WorkflowDefinition"/>'s <see cref="EventDefinition"/> collection
@@ -486,7 +486,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<Uri, Any>))]
         protected virtual OneOf<Uri, Any> ConstantsToken { get; set; }
 
-        private JObject _Constants;
+        private object _Constants;
         /// <summary>
         /// Gets/sets an <see cref="JObject"/> containing the <see cref="WorkflowDefinition"/>'s constants, which are globally accessible, read-only variables
         /// </summary>
@@ -494,7 +494,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
         [IgnoreDataMember]
-        public virtual Any Constants
+        public virtual object Constants
         {
             get
             {
@@ -506,8 +506,6 @@ namespace ServerlessWorkflow.Sdk.Models
                     else
                         this._Constants = this.ConstantsToken.Value2;
                 }
-                if (this._Constants == null)
-                    this._Constants = new JObject();
                 return this._Constants;
             }
             set
@@ -519,7 +517,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Constants = value;
-                this.ConstantsToken = new(value);
+                this.ConstantsToken = new((Any)Any.FromObject(value)); //todo: URGENT: create static method to create an Any (vs ProtoObject)
             }
         }
 
@@ -605,7 +603,6 @@ namespace ServerlessWorkflow.Sdk.Models
         [YamlIgnore]
         [IgnoreDataMember]
         public virtual Uri SecretshUri
-
         {
             get
             {
@@ -619,7 +616,7 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 this._Secrets = new ExternalDefinitionCollection<string>(value);
-                this.AuthToken = JToken.FromObject(value);
+                this.AuthToken = new(value);
             }
         }
 
@@ -694,7 +691,7 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 this._Auth = new ExternalDefinitionCollection<AuthenticationDefinition>(value);
-                this.AuthToken = JToken.FromObject(value);
+                this.AuthToken = new(value);
             }
         }
 

--- a/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
@@ -16,12 +16,14 @@
  */
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
+using ProtoBuf;
 using ServerlessWorkflow.Sdk.Services.FluentBuilders;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using YamlDotNet.Serialization;
@@ -31,17 +33,23 @@ namespace ServerlessWorkflow.Sdk.Models
     /// <summary>
     /// Represents the definition of a Serverless Workflow
     /// </summary>
+    [DataContract]
+    [ProtoContract]
     public class WorkflowDefinition
     {
 
         /// <summary>
         /// Gets/sets the <see cref="WorkflowDefinition"/>'s unique identifier
         /// </summary>
+        [ProtoMember(1)]
+        [DataMember(Order = 1)]
         public virtual string Id { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="WorkflowDefinition"/>'s domain-specific workflow identifier
         /// </summary>
+        [ProtoMember(2)]
+        [DataMember(Order = 2)]
         public virtual string Key { get; set; }
 
         /// <summary>
@@ -49,11 +57,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Newtonsoft.Json.JsonRequired]
         [Required]
+        [ProtoMember(3)]
+        [DataMember(Order = 3)]
         public virtual string Name { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="WorkflowDefinition"/>'s description
         /// </summary>
+        [ProtoMember(4)]
+        [DataMember(Order = 4)]
         public virtual string Description { get; set; }
 
         /// <summary>
@@ -61,11 +73,15 @@ namespace ServerlessWorkflow.Sdk.Models
         /// </summary>
         [Newtonsoft.Json.JsonRequired]
         [Required]
+        [ProtoMember(5)]
+        [DataMember(Order = 5)]
         public virtual string Version { get; set; }
 
         /// <summary>
         /// Gets/sets the <see cref="System.Version"/> of the Serverless Workflow schema to use
         /// </summary>
+        [ProtoMember(6)]
+        [DataMember(Order = 6)]
         public virtual string SpecVersion { get; set; } = typeof(WorkflowDefinition).Assembly.GetName().Version.ToString(2);
 
         /// <summary>
@@ -74,7 +90,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "dataInputSchema")]
         [System.Text.Json.Serialization.JsonPropertyName("dataInputSchema")]
         [YamlMember(Alias = "dataInputSchema")]
-        protected virtual JToken DataInputSchemaToken { get; set; }
+        [ProtoMember(7)]
+        [DataMember(Order = 7)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<JSchema, Uri>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<JSchema, Uri>))]
+        protected virtual OneOf<JSchema, Uri> DataInputSchemaToken { get; set; }
 
         private JSchema _DataInputSchema;
         /// <summary>
@@ -83,6 +103,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual JSchema DataInputSchema
         {
             get
@@ -90,10 +111,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._DataInputSchema == null
                     && this.DataInputSchemaToken != null)
                 {
-                    if (this.DataInputSchemaToken.Type == JTokenType.String)
-                        this._DataInputSchema = new ExternalJSchema(this.DataInputSchemaToken.ToObject<Uri>());
+                    if (this.DataInputSchemaToken.Value2 != null)
+                        this._DataInputSchema = new ExternalJSchema(this.DataInputSchemaToken.Value2);
                     else
-                        this._DataInputSchema = this.DataInputSchemaToken.ToObject<JSchema>();
+                        this._DataInputSchema = this.DataInputSchemaToken.Value1;
                 }
                 return this._DataInputSchema;
             }
@@ -106,7 +127,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._DataInputSchema = value;
-                this.DataInputSchemaToken = JToken.FromObject(value);
+                this.DataInputSchemaToken = new(value);
             }
         }
 
@@ -116,6 +137,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual Uri DataInputSchemaUri
         {
             get
@@ -130,7 +152,7 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 this._DataInputSchema = new ExternalJSchema(value);
-                this.DataInputSchemaToken = JToken.FromObject(value);
+                this.DataInputSchemaToken = new(value);
             }
         }
 
@@ -141,11 +163,15 @@ namespace ServerlessWorkflow.Sdk.Models
         [System.Text.Json.Serialization.JsonPropertyName("expressionLang")]
         [YamlMember(Alias = "expressionLang")]
         [Required]
+        [ProtoMember(8)]
+        [DataMember(Order = 8)]
         public virtual string ExpressionLanguage { get; set; } = "jq";
 
         /// <summary>
         /// Gets/sets a <see cref="List{T}"/> containing the <see cref="WorkflowDefinition"/>'s annotations
         /// </summary>
+        [ProtoMember(9)]
+        [DataMember(Order = 9)]
         public virtual List<string> Annotations { get; set; } = new List<string>();
 
         /// <summary>
@@ -154,6 +180,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "execTimeout")]
         [System.Text.Json.Serialization.JsonPropertyName("execTimeout")]
         [YamlMember(Alias = "execTimeout")]
+        [ProtoMember(10)]
+        [DataMember(Order = 10)]
         public virtual ExecutionTimeoutDefinition ExecutionTimeout { get; set; }
 
         /// <summary>
@@ -162,7 +190,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "start")]
         [System.Text.Json.Serialization.JsonPropertyName("start")]
         [YamlMember(Alias = "start")]
-        protected virtual JToken StartToken { get; set; }
+        [ProtoMember(11)]
+        [DataMember(Order = 11)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<string, StartDefinition>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<string, StartDefinition>))]
+        protected virtual OneOf<string, StartDefinition> StartToken { get; set; }
 
         private StartDefinition _Start;
         /// <summary>
@@ -171,6 +203,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual StartDefinition Start
         {
             get
@@ -178,10 +211,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Start == null
                     && this.StartToken != null)
                 {
-                    if (this.StartToken.Type == JTokenType.String)
-                        this._Start = new StartDefinition() { StateName = this.StartToken.ToObject<string>() };
+                    if (this.StartToken.Value2 == null)
+                        this._Start = new StartDefinition() { StateName = this.StartToken.Value1 };
                     else
-                        this._Start = this.StartToken.ToObject<StartDefinition>();
+                        this._Start = this.StartToken.Value2;
                 }
                 return this._Start;
             }
@@ -194,18 +227,22 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Start = value;
-                this.StartToken = JToken.FromObject(value);
+                this.StartToken = new(value);
             }
         }
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to keep instances of the <see cref="WorkflowDefinition"/> active event if there are no active execution paths. Instance can be terminated via 'terminate end definition' or reaching defined 'execTimeout'
         /// </summary>
+        [ProtoMember(12)]
+        [DataMember(Order = 12)]
         public virtual bool KeepActive { get; set; } = false;
 
         /// <summary>
         /// Gets/sets the <see cref="WorkflowDefinition"/>'s metadata
         /// </summary>
+        [ProtoMember(13)]
+        [DataMember(Order = 13)]
         public virtual JObject Metadata { get; set; } = new JObject();
 
         /// <summary>
@@ -214,7 +251,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "events")]
         [System.Text.Json.Serialization.JsonPropertyName("events")]
         [YamlMember(Alias = "events")]
-        protected virtual JToken EventsToken { get; set; }
+        [ProtoMember(14)]
+        [DataMember(Order = 14)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<EventDefinition>, Uri>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<EventDefinition>, Uri>))]
+        protected virtual OneOf<List<EventDefinition>, Uri> EventsToken { get; set; }
 
         private List<EventDefinition> _Events;
         /// <summary>
@@ -223,6 +264,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual List<EventDefinition> Events
         {
             get
@@ -230,10 +272,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Events == null
                     && this.EventsToken != null)
                 {
-                    if (this.EventsToken.Type == JTokenType.String)
-                        this._Events = new ExternalDefinitionCollection<EventDefinition>(this.EventsToken.ToObject<Uri>());
+                    if (this.EventsToken.Value1 == null)
+                        this._Events = new ExternalDefinitionCollection<EventDefinition>(this.EventsToken.Value2);
                     else
-                        this._Events = this.EventsToken.ToObject<List<EventDefinition>>();
+                        this._Events = this.EventsToken.Value1;
                 }
                 if (this._Events == null)
                     this._Events = new List<EventDefinition>();
@@ -248,7 +290,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Events = value;
-                this.EventsToken = JToken.FromObject(value);
+                this.EventsToken = new(value);
             }
         }
 
@@ -258,6 +300,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual Uri EventsUri
         {
             get
@@ -272,7 +315,7 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 this._Events = new ExternalDefinitionCollection<EventDefinition>(value);
-                this.EventsToken = JToken.FromObject(value);
+                this.EventsToken = new(value);
             }
         }
 
@@ -282,7 +325,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "functions")]
         [System.Text.Json.Serialization.JsonPropertyName("functions")]
         [YamlMember(Alias = "functions")]
-        protected virtual JToken FunctionsToken { get; set; }
+        [ProtoMember(15)]
+        [DataMember(Order = 15)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<FunctionDefinition>, Uri>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<FunctionDefinition>, Uri>))]
+        protected virtual OneOf<List<FunctionDefinition>, Uri> FunctionsToken { get; set; }
 
         private List<FunctionDefinition> _Functions;
         /// <summary>
@@ -291,6 +338,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual List<FunctionDefinition> Functions
         {
             get
@@ -298,10 +346,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Functions == null
                     && this.FunctionsToken != null)
                 {
-                    if (this.FunctionsToken.Type == JTokenType.String)
-                        this._Functions = new ExternalDefinitionCollection<FunctionDefinition>(this.FunctionsToken.ToObject<Uri>());
+                    if (this.FunctionsToken.Value1 == null)
+                        this._Functions = new ExternalDefinitionCollection<FunctionDefinition>(this.FunctionsToken.Value2);
                     else
-                        this._Functions = this.FunctionsToken.ToObject<List<FunctionDefinition>>();
+                        this._Functions = this.FunctionsToken.Value1;
                 }
                 if (this._Functions == null)
                     this._Functions = new List<FunctionDefinition>();
@@ -316,7 +364,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Functions = value;
-                this.FunctionsToken = JToken.FromObject(value);
+                this.FunctionsToken = new(value);
             }
         }
 
@@ -326,6 +374,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual Uri FunctionsUri
         {
             get
@@ -340,7 +389,7 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 this._Functions = new ExternalDefinitionCollection<FunctionDefinition>(value);
-                this.FunctionsToken = JToken.FromObject(value);
+                this.FunctionsToken = new(value);
             }
         }
 
@@ -350,7 +399,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "retries")]
         [System.Text.Json.Serialization.JsonPropertyName("retries")]
         [YamlMember(Alias = "retries")]
-        protected virtual JToken RetriesToken { get; set; }
+        [ProtoMember(16)]
+        [DataMember(Order = 16)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<RetryStrategyDefinition>, Uri>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<RetryStrategyDefinition>, Uri>))]
+        protected virtual OneOf<List<RetryStrategyDefinition>, Uri> RetriesToken { get; set; }
 
         private List<RetryStrategyDefinition> _Retries;
         /// <summary>
@@ -359,6 +412,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual List<RetryStrategyDefinition> Retries
         {
             get
@@ -366,10 +420,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Retries == null
                     && this.RetriesToken != null)
                 {
-                    if (this.RetriesToken.Type == JTokenType.String)
-                        this._Retries = new ExternalDefinitionCollection<RetryStrategyDefinition>(this.RetriesToken.ToObject<Uri>());
+                    if (this.RetriesToken.Value1 == null)
+                        this._Retries = new ExternalDefinitionCollection<RetryStrategyDefinition>(this.RetriesToken.Value2);
                     else
-                        this._Retries = this.RetriesToken.ToObject<List<RetryStrategyDefinition>>();
+                        this._Retries = this.RetriesToken.Value1;
                 }
                 if (this._Retries == null)
                     this._Retries = new List<RetryStrategyDefinition>();
@@ -384,7 +438,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Retries = value;
-                this.RetriesToken = JToken.FromObject(value);
+                this.RetriesToken = new(value);
             }
         }
 
@@ -394,6 +448,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual Uri RetriesUri
         {
             get
@@ -408,13 +463,15 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 this._Retries = new ExternalDefinitionCollection<RetryStrategyDefinition>(value);
-                this.RetriesToken = JToken.FromObject(value);
+                this.RetriesToken = new(value);
             }
         }
 
         /// <summary>
         /// Gets/sets an <see cref="IEnumerable{T}"/> containing the <see cref="WorkflowDefinition"/>'s <see cref="StateDefinition"/>s
         /// </summary>
+        [ProtoMember(17)]
+        [DataMember(Order = 17)]
         public virtual List<StateDefinition> States { get; set; } = new List<StateDefinition>();
 
         /// <summary>
@@ -423,7 +480,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "constants")]
         [System.Text.Json.Serialization.JsonPropertyName("constants")]
         [YamlMember(Alias = "constants")]
-        protected virtual JToken ConstantsToken { get; set; }
+        [ProtoMember(18)]
+        [DataMember(Order = 18)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<Uri, Any>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<Uri, Any>))]
+        protected virtual OneOf<Uri, Any> ConstantsToken { get; set; }
 
         private JObject _Constants;
         /// <summary>
@@ -432,17 +493,18 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
-        public virtual JObject Constants
+        [IgnoreDataMember]
+        public virtual Any Constants
         {
             get
             {
                 if (this._Constants == null
                     && this.ConstantsToken != null)
                 {
-                    if (this.ConstantsToken.Type == JTokenType.String)
-                        this._Constants = new ExternalDefinition(this.ConstantsToken.ToObject<Uri>());
+                    if (this.ConstantsToken.Value2 == null)
+                        this._Constants = new ExternalDefinition(this.ConstantsToken.Value1);
                     else
-                        this._Constants = (JObject)this.ConstantsToken;
+                        this._Constants = this.ConstantsToken.Value2;
                 }
                 if (this._Constants == null)
                     this._Constants = new JObject();
@@ -457,7 +519,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Constants = value;
-                this.ConstantsToken = value;
+                this.ConstantsToken = new(value);
             }
         }
 
@@ -467,6 +529,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual Uri ConstantsUri
         {
             get
@@ -481,7 +544,7 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 this._Constants = new ExternalDefinition(value);
-                this.ConstantsToken = JToken.FromObject(value);
+                this.ConstantsToken = new(value);
             }
         }
 
@@ -491,7 +554,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "secrets")]
         [System.Text.Json.Serialization.JsonPropertyName("secrets")]
         [YamlMember(Alias = "secrets")]
-        protected virtual JToken SecretsToken { get; set; }
+        [ProtoMember(19)]
+        [DataMember(Order = 19)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<string>, Uri>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<string>, Uri>))]
+        protected virtual OneOf<List<string>, Uri> SecretsToken { get; set; }
 
         private List<string> _Secrets;
         /// <summary>
@@ -500,6 +567,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual List<string> Secrets
         {
             get
@@ -507,10 +575,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Secrets == null
                     && this.SecretsToken != null)
                 {
-                    if (this.SecretsToken.Type == JTokenType.String)
-                        this._Secrets = new ExternalDefinitionCollection<string>(this.SecretsToken.ToObject<Uri>());
+                    if (this.SecretsToken.Value1 == null)
+                        this._Secrets = new ExternalDefinitionCollection<string>(this.SecretsToken.Value2);
                     else
-                        this._Secrets = this.SecretsToken.ToObject<List<string>>();
+                        this._Secrets = this.SecretsToken.Value1;
                 }
                 if (this._Secrets == null)
                     this._Secrets = new List<string>();
@@ -525,7 +593,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Secrets = value;
-                this.SecretsToken = JToken.FromObject(value);
+                this.SecretsToken = new(value);
             }
         }
 
@@ -535,6 +603,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual Uri SecretshUri
 
         {
@@ -560,7 +629,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "auth")]
         [System.Text.Json.Serialization.JsonPropertyName("auth")]
         [YamlMember(Alias = "auth")]
-        protected virtual JToken AuthToken { get; set; }
+        [ProtoMember(20)]
+        [DataMember(Order = 20)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<AuthenticationDefinition>, Uri>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<AuthenticationDefinition>, Uri>))]
+        protected virtual OneOf<List<AuthenticationDefinition>, Uri> AuthToken { get; set; }
 
         private List<AuthenticationDefinition> _Auth;
         /// <summary>
@@ -569,6 +642,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual List<AuthenticationDefinition> Auth
         {
             get
@@ -576,10 +650,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Auth == null
                     && this.AuthToken != null)
                 {
-                    if (this.AuthToken.Type == JTokenType.String)
-                        this._Auth = new ExternalDefinitionCollection<AuthenticationDefinition>(this.AuthToken.ToObject<Uri>());
+                    if (this.AuthToken.Value1 == null)
+                        this._Auth = new ExternalDefinitionCollection<AuthenticationDefinition>(this.AuthToken.Value2);
                     else
-                        this._Auth = this.AuthToken.ToObject<List<AuthenticationDefinition>>();
+                        this._Auth = this.AuthToken.Value1;
                 }
                 if (this._Auth == null)
                     this._Auth = new List<AuthenticationDefinition>();
@@ -594,7 +668,7 @@ namespace ServerlessWorkflow.Sdk.Models
                     return;
                 }
                 this._Auth = value;
-                this.AuthToken = JToken.FromObject(value);
+                this.AuthToken = new(value);
             }
         }
 
@@ -604,6 +678,7 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [IgnoreDataMember]
         public virtual Uri AuthUri
 
         {

--- a/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
@@ -111,10 +111,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._DataInputSchema == null
                     && this.DataInputSchemaToken != null)
                 {
-                    if (this.DataInputSchemaToken.Value2 != null)
-                        this._DataInputSchema = new ExternalJSchema(this.DataInputSchemaToken.Value2);
+                    if (this.DataInputSchemaToken.T2Value != null)
+                        this._DataInputSchema = new ExternalJSchema(this.DataInputSchemaToken.T2Value);
                     else
-                        this._DataInputSchema = this.DataInputSchemaToken.Value1;
+                        this._DataInputSchema = this.DataInputSchemaToken.T1Value;
                 }
                 return this._DataInputSchema;
             }
@@ -187,54 +187,11 @@ namespace ServerlessWorkflow.Sdk.Models
         /// <summary>
         /// Gets/sets the <see cref="JToken"/> that defines the <see cref="WorkflowDefinition"/>'s start
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "start")]
-        [System.Text.Json.Serialization.JsonPropertyName("start")]
-        [YamlMember(Alias = "start")]
-        [ProtoMember(11, Name = "start")]
-        [DataMember(Order = 11, Name = "start")]
+        [ProtoMember(11)]
+        [DataMember(Order = 11)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<StartDefinition, string>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<StartDefinition, string>))]
-        protected virtual OneOf<StartDefinition, string> StartToken { get; set; }
-
-        /// <summary>
-        /// Gets/sets the <see cref="WorkflowDefinition"/>'s <see cref="StartDefinition"/>
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual StartDefinition Start
-        {
-            get
-            {
-                return this.StartToken;
-            }
-            set
-            {
-                    this.StartToken = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets/sets the <see cref="WorkflowDefinition"/>'s start <see cref="StateDefinition"/>. If not set, defaults to the first defined <see cref="StateDefinition"/>
-        /// </summary>
-        [Newtonsoft.Json.JsonIgnore]
-        [System.Text.Json.Serialization.JsonIgnore]
-        [YamlIgnore]
-        [ProtoIgnore]
-        [IgnoreDataMember]
-        public virtual string StartState
-        {
-            get
-            {
-                return this.StartToken;
-            }
-            set
-            {
-                this.StartToken = value;
-            }
-        }
+        public virtual OneOf<StartDefinition, string> Start { get; set; }
 
         /// <summary>
         /// Gets/sets a boolean indicating whether or not to keep instances of the <see cref="WorkflowDefinition"/> active event if there are no active execution paths. Instance can be terminated via 'terminate end definition' or reaching defined 'execTimeout'
@@ -277,10 +234,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Events == null
                     && this.EventsToken != null)
                 {
-                    if (this.EventsToken.Value1 == null)
-                        this._Events = new ExternalDefinitionCollection<EventDefinition>(this.EventsToken.Value2);
+                    if (this.EventsToken.T1Value == null)
+                        this._Events = new ExternalDefinitionCollection<EventDefinition>(this.EventsToken.T2Value);
                     else
-                        this._Events = this.EventsToken.Value1;
+                        this._Events = this.EventsToken.T1Value;
                 }
                 return this._Events;
             }
@@ -349,10 +306,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Functions == null
                     && this.FunctionsToken != null)
                 {
-                    if (this.FunctionsToken.Value1 == null)
-                        this._Functions = new ExternalDefinitionCollection<FunctionDefinition>(this.FunctionsToken.Value2);
+                    if (this.FunctionsToken.T1Value == null)
+                        this._Functions = new ExternalDefinitionCollection<FunctionDefinition>(this.FunctionsToken.T2Value);
                     else
-                        this._Functions = this.FunctionsToken.Value1;
+                        this._Functions = this.FunctionsToken.T1Value;
                 }
                 return this._Functions;
             }
@@ -421,10 +378,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Retries == null
                     && this.RetriesToken != null)
                 {
-                    if (this.RetriesToken.Value1 == null)
-                        this._Retries = new ExternalDefinitionCollection<RetryStrategyDefinition>(this.RetriesToken.Value2);
+                    if (this.RetriesToken.T1Value == null)
+                        this._Retries = new ExternalDefinitionCollection<RetryStrategyDefinition>(this.RetriesToken.T2Value);
                     else
-                        this._Retries = this.RetriesToken.Value1;
+                        this._Retries = this.RetriesToken.T1Value;
                 }
                 return this._Retries;
             }
@@ -500,10 +457,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Constants == null
                     && this.ConstantsToken != null)
                 {
-                    if (this.ConstantsToken.Value2 == null)
-                        this._Constants = new ExternalDefinition(this.ConstantsToken.Value1);
+                    if (this.ConstantsToken.T2Value == null)
+                        this._Constants = new ExternalDefinition(this.ConstantsToken.T1Value);
                     else
-                        this._Constants = this.ConstantsToken.Value2;
+                        this._Constants = this.ConstantsToken.T2Value;
                 }
                 return this._Constants;
             }
@@ -572,10 +529,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Secrets == null
                     && this.SecretsToken != null)
                 {
-                    if (this.SecretsToken.Value1 == null)
-                        this._Secrets = new ExternalDefinitionCollection<string>(this.SecretsToken.Value2);
+                    if (this.SecretsToken.T1Value == null)
+                        this._Secrets = new ExternalDefinitionCollection<string>(this.SecretsToken.T2Value);
                     else
-                        this._Secrets = this.SecretsToken.Value1;
+                        this._Secrets = this.SecretsToken.T1Value;
                 }
                 return this._Secrets;
             }
@@ -644,10 +601,10 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Auth == null
                     && this.AuthToken != null)
                 {
-                    if (this.AuthToken.Value1 == null)
-                        this._Auth = new ExternalDefinitionCollection<AuthenticationDefinition>(this.AuthToken.Value2);
+                    if (this.AuthToken.T1Value == null)
+                        this._Auth = new ExternalDefinitionCollection<AuthenticationDefinition>(this.AuthToken.T2Value);
                     else
-                        this._Auth = this.AuthToken.Value1;
+                        this._Auth = this.AuthToken.T1Value;
                 }
                 return this._Auth;
             }

--- a/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
@@ -90,8 +90,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "dataInputSchema")]
         [System.Text.Json.Serialization.JsonPropertyName("dataInputSchema")]
         [YamlMember(Alias = "dataInputSchema")]
-        [ProtoMember(7)]
-        [DataMember(Order = 7)]
+        [ProtoMember(7, Name = "dataInputSchema")]
+        [DataMember(Order = 7, Name = "dataInputSchema")]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<JSchema, Uri>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<JSchema, Uri>))]
         protected virtual OneOf<JSchema, Uri> DataInputSchemaToken { get; set; }
@@ -163,8 +163,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [System.Text.Json.Serialization.JsonPropertyName("expressionLang")]
         [YamlMember(Alias = "expressionLang")]
         [Required]
-        [ProtoMember(8)]
-        [DataMember(Order = 8)]
+        [ProtoMember(8, Name = "expressionLang")]
+        [DataMember(Order = 8, Name = "expressionLang")]
         public virtual string ExpressionLanguage { get; set; } = "jq";
 
         /// <summary>
@@ -180,8 +180,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "execTimeout")]
         [System.Text.Json.Serialization.JsonPropertyName("execTimeout")]
         [YamlMember(Alias = "execTimeout")]
-        [ProtoMember(10)]
-        [DataMember(Order = 10)]
+        [ProtoMember(10, Name = "execTimeout")]
+        [DataMember(Order = 10, Name = "execTimeout")]
         public virtual ExecutionTimeoutDefinition ExecutionTimeout { get; set; }
 
         /// <summary>
@@ -190,11 +190,11 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "start")]
         [System.Text.Json.Serialization.JsonPropertyName("start")]
         [YamlMember(Alias = "start")]
-        [ProtoMember(11)]
-        [DataMember(Order = 11)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<string, StartDefinition>))]
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<string, StartDefinition>))]
-        protected virtual OneOf<string, StartDefinition> StartToken { get; set; }
+        [ProtoMember(11, Name = "start")]
+        [DataMember(Order = 11, Name = "start")]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<StartDefinition, string>))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<StartDefinition, string>))]
+        protected virtual OneOf<StartDefinition, string> StartToken { get; set; }
 
         private StartDefinition _Start;
         /// <summary>
@@ -211,10 +211,11 @@ namespace ServerlessWorkflow.Sdk.Models
                 if (this._Start == null
                     && this.StartToken != null)
                 {
-                    if (this.StartToken.Value2 == null)
-                        this._Start = new StartDefinition() { StateName = this.StartToken.Value1 };
+                    if (this.StartToken.Value1 == null
+                        && !string.IsNullOrWhiteSpace(this.StartToken.Value2))
+                        this._Start = new StartDefinition() { StateName = this.StartToken.Value2 };
                     else
-                        this._Start = this.StartToken.Value2;
+                        this._Start = this.StartToken.Value1;
                 }
                 return this._Start;
             }
@@ -251,8 +252,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "events")]
         [System.Text.Json.Serialization.JsonPropertyName("events")]
         [YamlMember(Alias = "events")]
-        [ProtoMember(14)]
-        [DataMember(Order = 14)]
+        [ProtoMember(14, Name = "events")]
+        [DataMember(Order = 14, Name = "events")]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<EventDefinition>, Uri>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<EventDefinition>, Uri>))]
         protected virtual OneOf<List<EventDefinition>, Uri> EventsToken { get; set; }
@@ -277,8 +278,6 @@ namespace ServerlessWorkflow.Sdk.Models
                     else
                         this._Events = this.EventsToken.Value1;
                 }
-                if (this._Events == null)
-                    this._Events = new List<EventDefinition>();
                 return this._Events;
             }
             set
@@ -325,8 +324,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "functions")]
         [System.Text.Json.Serialization.JsonPropertyName("functions")]
         [YamlMember(Alias = "functions")]
-        [ProtoMember(15)]
-        [DataMember(Order = 15)]
+        [ProtoMember(15, Name = "functions")]
+        [DataMember(Order = 15, Name = "functions")]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<FunctionDefinition>, Uri>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<FunctionDefinition>, Uri>))]
         protected virtual OneOf<List<FunctionDefinition>, Uri> FunctionsToken { get; set; }
@@ -351,8 +350,6 @@ namespace ServerlessWorkflow.Sdk.Models
                     else
                         this._Functions = this.FunctionsToken.Value1;
                 }
-                if (this._Functions == null)
-                    this._Functions = new List<FunctionDefinition>();
                 return this._Functions;
             }
             set
@@ -399,8 +396,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "retries")]
         [System.Text.Json.Serialization.JsonPropertyName("retries")]
         [YamlMember(Alias = "retries")]
-        [ProtoMember(16)]
-        [DataMember(Order = 16)]
+        [ProtoMember(16, Name = "retries")]
+        [DataMember(Order = 16, Name = "retries")]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<RetryStrategyDefinition>, Uri>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<RetryStrategyDefinition>, Uri>))]
         protected virtual OneOf<List<RetryStrategyDefinition>, Uri> RetriesToken { get; set; }
@@ -425,8 +422,6 @@ namespace ServerlessWorkflow.Sdk.Models
                     else
                         this._Retries = this.RetriesToken.Value1;
                 }
-                if (this._Retries == null)
-                    this._Retries = new List<RetryStrategyDefinition>();
                 return this._Retries;
             }
             set
@@ -480,8 +475,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "constants")]
         [System.Text.Json.Serialization.JsonPropertyName("constants")]
         [YamlMember(Alias = "constants")]
-        [ProtoMember(18)]
-        [DataMember(Order = 18)]
+        [ProtoMember(18, Name = "constants")]
+        [DataMember(Order = 18, Name = "constants")]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<Uri, Any>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<Uri, Any>))]
         protected virtual OneOf<Uri, Any> ConstantsToken { get; set; }
@@ -552,8 +547,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "secrets")]
         [System.Text.Json.Serialization.JsonPropertyName("secrets")]
         [YamlMember(Alias = "secrets")]
-        [ProtoMember(19)]
-        [DataMember(Order = 19)]
+        [ProtoMember(19, Name = "secrets")]
+        [DataMember(Order = 19, Name = "secrets")]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<string>, Uri>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<string>, Uri>))]
         protected virtual OneOf<List<string>, Uri> SecretsToken { get; set; }
@@ -578,8 +573,6 @@ namespace ServerlessWorkflow.Sdk.Models
                     else
                         this._Secrets = this.SecretsToken.Value1;
                 }
-                if (this._Secrets == null)
-                    this._Secrets = new List<string>();
                 return this._Secrets;
             }
             set
@@ -626,8 +619,8 @@ namespace ServerlessWorkflow.Sdk.Models
         [Newtonsoft.Json.JsonProperty(PropertyName = "auth")]
         [System.Text.Json.Serialization.JsonPropertyName("auth")]
         [YamlMember(Alias = "auth")]
-        [ProtoMember(20)]
-        [DataMember(Order = 20)]
+        [ProtoMember(20, Name = "auth")]
+        [DataMember(Order = 20, Name = "auth")]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.OneOfConverter<List<AuthenticationDefinition>, Uri>))]
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<List<AuthenticationDefinition>, Uri>))]
         protected virtual OneOf<List<AuthenticationDefinition>, Uri> AuthToken { get; set; }
@@ -652,8 +645,6 @@ namespace ServerlessWorkflow.Sdk.Models
                     else
                         this._Auth = this.AuthToken.Value1;
                 }
-                if (this._Auth == null)
-                    this._Auth = new List<AuthenticationDefinition>();
                 return this._Auth;
             }
             set

--- a/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/WorkflowDefinition.cs
@@ -196,39 +196,43 @@ namespace ServerlessWorkflow.Sdk.Models
         [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.Converters.OneOfConverter<StartDefinition, string>))]
         protected virtual OneOf<StartDefinition, string> StartToken { get; set; }
 
-        private StartDefinition _Start;
         /// <summary>
         /// Gets/sets the <see cref="WorkflowDefinition"/>'s <see cref="StartDefinition"/>
         /// </summary>
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
         [YamlIgnore]
+        [ProtoIgnore]
         [IgnoreDataMember]
         public virtual StartDefinition Start
         {
             get
             {
-                if (this._Start == null
-                    && this.StartToken != null)
-                {
-                    if (this.StartToken.Value1 == null
-                        && !string.IsNullOrWhiteSpace(this.StartToken.Value2))
-                        this._Start = new StartDefinition() { StateName = this.StartToken.Value2 };
-                    else
-                        this._Start = this.StartToken.Value1;
-                }
-                return this._Start;
+                return this.StartToken;
             }
             set
             {
-                if (value == null)
-                {
-                    this._Start = null;
-                    this.StartToken = null;
-                    return;
-                }
-                this._Start = value;
-                this.StartToken = new(value);
+                    this.StartToken = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets the <see cref="WorkflowDefinition"/>'s start <see cref="StateDefinition"/>. If not set, defaults to the first defined <see cref="StateDefinition"/>
+        /// </summary>
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [YamlIgnore]
+        [ProtoIgnore]
+        [IgnoreDataMember]
+        public virtual string StartState
+        {
+            get
+            {
+                return this.StartToken;
+            }
+            set
+            {
+                this.StartToken = value;
             }
         }
 

--- a/src/ServerlessWorkflow.Sdk/Properties/GlobalUsings.cs
+++ b/src/ServerlessWorkflow.Sdk/Properties/GlobalUsings.cs
@@ -1,0 +1,2 @@
+﻿global using ProtoBuf;
+global using System.Runtime.Serialization;

--- a/src/ServerlessWorkflow.Sdk/Serialization/Json/JsonElementExtensions.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/Json/JsonElementExtensions.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Defines extensions for <see cref="JsonElement"/>s
+    /// </summary>
+    public static class JsonElementExtensions
+    {
+
+        /// <summary>
+        /// Converts the <see cref="JsonElement"/> into a new object of the specified type
+        /// </summary>
+        /// <typeparam name="T">The type of object to convert the <see cref="JsonElement"/> into</typeparam>
+        /// <param name="element">The <see cref="JsonElement"/> to convert</param>
+        /// <returns>A new object of the specified type</returns>
+        public static T ToObject<T>(this JsonElement element)
+        {
+            var json = element.GetRawText();
+            return JsonSerializer.Deserialize<T>(json);
+        }
+
+        /// <summary>
+        /// Converts the <see cref="JsonDocument"/> into a new object of the specified type
+        /// </summary>
+        /// <typeparam name="T">The type of object to convert the <see cref="JsonDocument"/> into</typeparam>
+        /// <param name="document">The <see cref="JsonDocument"/> to convert</param>
+        /// <returns>A new object of the specified type</returns>
+        public static T ToObject<T>(this JsonDocument document)
+        {
+            var json = document.RootElement.GetRawText();
+            return JsonSerializer.Deserialize<T>(json);
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Serialization/Json/OneOfConverter.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/Json/OneOfConverter.cs
@@ -47,10 +47,10 @@ namespace System.Text.Json.Serialization.Converters
         public override void Write(Utf8JsonWriter writer, OneOf<T1, T2> value, JsonSerializerOptions options)
         {
             var json = string.Empty;
-            if (value.Value1 != null)
-                json = JsonSerializer.Serialize(value.Value1);
+            if (value.T1Value != null)
+                json = JsonSerializer.Serialize(value.T1Value);
             else
-                json = JsonSerializer.Serialize(value.Value2);
+                json = JsonSerializer.Serialize(value.T2Value);
             writer.WriteStringValue(json);
         }
 

--- a/src/ServerlessWorkflow.Sdk/Serialization/Json/OneOfConverter.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/Json/OneOfConverter.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using ServerlessWorkflow.Sdk.Models;
+
+namespace System.Text.Json.Serialization.Converters
+{
+
+    /// <summary>
+    /// Represents the service used to convert <see cref="OneOf{T1, T2}"/>
+    /// </summary>
+    /// <typeparam name="T1">The first type alternative</typeparam>
+    /// <typeparam name="T2">The second type alternative</typeparam>
+    public class OneOfConverter<T1, T2>
+        : JsonConverter<OneOf<T1, T2>>
+    {
+
+        /// <inheritdoc/>
+        public override OneOf<T1, T2> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var doc = JsonDocument.ParseValue(ref reader);
+            try
+            {
+                return new(doc.ToObject<T1>());
+            }
+            catch
+            {
+                return new(doc.ToObject<T2>());
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, OneOf<T1, T2> value, JsonSerializerOptions options)
+        {
+            var json = string.Empty;
+            if (value.Value1 != null)
+                json = JsonSerializer.Serialize(value.Value1);
+            else
+                json = JsonSerializer.Serialize(value.Value2);
+            writer.WriteStringValue(json);
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Serialization/NewtonsoftJson/AnyConverter.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/NewtonsoftJson/AnyConverter.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Newtonsoft.Json.Linq;
+using ServerlessWorkflow.Sdk.Models;
+using System;
+
+namespace Newtonsoft.Json.Converters
+{
+    /// <summary>
+    /// Represents the <see cref="JsonConverter"/> used to convert from and to <see cref="Any"/> instances
+    /// </summary>
+    public class AnyConverter
+        : JsonConverter<Any>
+    {
+
+        /// <inheritdoc/>
+        public override Any ReadJson(JsonReader reader, Type objectType, Any existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var jobject = (JObject)JObject.ReadFrom(reader);
+            var any = new Any();
+            foreach (var property in jobject.Properties())
+            {
+                var value = JsonConvert.DeserializeObject(property.Value.ToString(Formatting.None));
+                any.Set(property.Name, value);
+            }
+            return any;
+        }
+
+        /// <inheritdoc/>
+        public override void WriteJson(JsonWriter writer, Any value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value.ToObject());
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Serialization/NewtonsoftJson/OneOfConverter.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/NewtonsoftJson/OneOfConverter.cs
@@ -47,10 +47,10 @@ namespace Newtonsoft.Json.Converters
         /// <inheritdoc/>
         public override void WriteJson(JsonWriter writer, OneOf<T1, T2> value, JsonSerializer serializer)
         {
-            if (value.Value1 != null)
-                serializer.Serialize(writer, value.Value1);
+            if (value.T1Value != null)
+                serializer.Serialize(writer, value.T1Value);
             else
-                serializer.Serialize(writer, value.Value2);
+                serializer.Serialize(writer, value.T2Value);
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Serialization/NewtonsoftJson/OneOfConverter.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/NewtonsoftJson/OneOfConverter.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Newtonsoft.Json.Linq;
+using ServerlessWorkflow.Sdk.Models;
+using System;
+
+namespace Newtonsoft.Json.Converters
+{
+
+    /// <summary>
+    /// Represents the service used to convert <see cref="OneOf{T1, T2}"/>
+    /// </summary>
+    /// <typeparam name="T1">The first type alternative</typeparam>
+    /// <typeparam name="T2">The second type alternative</typeparam>
+    public class OneOfConverter<T1, T2>
+        : JsonConverter<OneOf<T1, T2>>
+    {
+
+        /// <inheritdoc/>
+        public override OneOf<T1, T2> ReadJson(JsonReader reader, Type objectType, OneOf<T1, T2> existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var token = JToken.ReadFrom(reader);
+            try
+            {
+                return new(token.ToObject<T1>());
+            }
+            catch
+            {
+                return new(token.ToObject<T2>());
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void WriteJson(JsonWriter writer, OneOf<T1, T2> value, JsonSerializer serializer)
+        {
+            if (value.Value1 != null)
+                serializer.Serialize(writer, value.Value1);
+            else
+                serializer.Serialize(writer, value.Value2);
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/AnyConverter.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/AnyConverter.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Newtonsoft.Json.Linq;
+using ServerlessWorkflow.Sdk.Models;
+using System;
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Serialization
+{
+    /// <summary>
+    /// Represents the <see cref="IYamlTypeConverter"/> used to serialize and deserialize <see cref="Any"/> instances
+    /// </summary>
+    public class AnyConverter
+        : IYamlTypeConverter
+    {
+
+        /// <inheritdoc/>
+        public virtual bool Accepts(Type type)
+        {
+            return typeof(Any).IsAssignableFrom(type);
+        }
+
+        /// <inheritdoc/>
+        public virtual object ReadYaml(IParser parser, Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public virtual void WriteYaml(IEmitter emitter, object value, Type type)
+        {
+            var token = JToken.FromObject(value);
+            new JTokenSerializer().WriteYaml(emitter, token, typeof(JToken));
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/AnyDeserializer.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/AnyDeserializer.cs
@@ -48,17 +48,9 @@ namespace YamlDotNet.Serialization
             value = null;
             if (!typeof(Any).IsAssignableFrom(expectedType))
                 return this.Inner.Deserialize(reader, expectedType, nestedObjectDeserializer, out value);
-            try
-            {
-                value = Yaml.Deserialize(reader, typeof(Dictionary<string, object>));
-                value = new Any((Dictionary<string, object>)value);
-                return true;
-            }
-            catch(Exception ex)
-            {
-
-                return false;
-            }
+            value = Yaml.Deserialize(reader, typeof(Dictionary<string, object>));
+            value = new Any((Dictionary<string, object>)value);
+            return true;
         }
 
     }

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/JTokenSerializer.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/JTokenSerializer.cs
@@ -22,6 +22,7 @@ using YamlDotNet.Core.Events;
 
 namespace YamlDotNet.Serialization
 {
+
     /// <summary>
     /// Represents the <see cref="IYamlTypeConverter"/> used to serialize <see cref="JToken"/>s
     /// </summary>

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/OneOfConverter.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/OneOfConverter.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Newtonsoft.Json.Linq;
+using ServerlessWorkflow.Sdk;
+using ServerlessWorkflow.Sdk.Models;
+using System;
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Serialization
+{
+    /// <summary>
+    /// Represents the <see cref="IYamlTypeConverter"/> used to serialize and deserialize <see cref="OneOf{T1, T2}"/> instances
+    /// </summary>
+    public class OneOfConverter
+        : IYamlTypeConverter
+    {
+
+        /// <inheritdoc/>
+        public virtual bool Accepts(Type type)
+        {
+            return type.GetGenericType(typeof(OneOf<,>)) != null;
+        }
+
+        /// <inheritdoc/>
+        public virtual object ReadYaml(IParser parser, Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public virtual void WriteYaml(IEmitter emitter, object value, Type type)
+        {
+            var token = JToken.FromObject(value);
+            new JTokenSerializer().WriteYaml(emitter, token, typeof(JToken));
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/OneOfConverter.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/OneOfConverter.cs
@@ -44,7 +44,10 @@ namespace YamlDotNet.Serialization
         /// <inheritdoc/>
         public virtual void WriteYaml(IEmitter emitter, object value, Type type)
         {
-            var token = JToken.FromObject(value);
+            var toSerialize = value;
+            if (value is IOneOf oneOf)
+                toSerialize = oneOf.GetValue();
+            var token = JToken.FromObject(toSerialize);
             new JTokenSerializer().WriteYaml(emitter, token, typeof(JToken));
         }
 

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/OneOfDeserializer.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/OneOfDeserializer.cs
@@ -21,6 +21,7 @@ using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization
 {
+
     /// <summary>
     /// Represents an <see cref="INodeDeserializer"/> used to deserialize <see cref="OneOf{T1, T2}"/> instances
     /// </summary>
@@ -46,20 +47,20 @@ namespace YamlDotNet.Serialization
         public virtual bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object> nestedObjectDeserializer, out object value)
         {
             value = null;
-            var anyOfType = expectedType.GetGenericType(typeof(OneOf<,>));
-            if(anyOfType == null || !anyOfType.IsAssignableFrom(expectedType))
+            var oneOfType = expectedType.GetGenericType(typeof(OneOf<,>));
+            if(oneOfType == null || !oneOfType.IsAssignableFrom(expectedType))
                 return this.Inner.Deserialize(reader, expectedType, nestedObjectDeserializer, out value);
-            var t1 = anyOfType.GetGenericArguments()[0];
-            var t2 = anyOfType.GetGenericArguments()[1];
+            var t1 = oneOfType.GetGenericArguments()[0];
+            var t2 = oneOfType.GetGenericArguments()[1];
             try
             {
-                value = Yaml.Deserialize(reader, t1);
+                value = nestedObjectDeserializer(reader, t1);
             }
             catch
             {
-                value = Yaml.Deserialize(reader, t2);
+                value = nestedObjectDeserializer(reader, t2);
             }
-            value = Activator.CreateInstance(anyOfType, new object[] { value });
+            value = Activator.CreateInstance(oneOfType, new object[] { value });
             return true;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/OneOfDeserializer.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/OneOfDeserializer.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using ServerlessWorkflow.Sdk;
+using ServerlessWorkflow.Sdk.Models;
+using System;
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Serialization
+{
+    /// <summary>
+    /// Represents an <see cref="INodeDeserializer"/> used to deserialize <see cref="OneOf{T1, T2}"/> instances
+    /// </summary>
+    public class OneOfDeserializer
+        : INodeDeserializer
+    {
+
+        /// <summary>
+        /// Initializes a new <see cref="OneOfDeserializer"/>
+        /// </summary>
+        /// <param name="inner">The inner <see cref="INodeDeserializer"/></param>
+        public OneOfDeserializer(INodeDeserializer inner)
+        {
+            this.Inner = inner;
+        }
+
+        /// <summary>
+        /// Gets the inner <see cref="INodeDeserializer"/>
+        /// </summary>
+        protected INodeDeserializer Inner { get; }
+
+        /// <inheritdoc/>
+        public virtual bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object> nestedObjectDeserializer, out object value)
+        {
+            value = null;
+            var anyOfType = expectedType.GetGenericType(typeof(OneOf<,>));
+            if(anyOfType != null)
+            {
+
+            }
+            if(anyOfType == null || !anyOfType.IsAssignableFrom(expectedType))
+                return this.Inner.Deserialize(reader, expectedType, nestedObjectDeserializer, out value);
+            var t1 = anyOfType.GetGenericArguments()[0];
+            var t2 = anyOfType.GetGenericArguments()[1];
+            try
+            {
+                value = Yaml.Deserialize(reader, t1);
+            }
+            catch
+            {
+                value = Yaml.Deserialize(reader, t2);
+            }
+            value = Activator.CreateInstance(anyOfType, new object[] { value });
+            return true;
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/ParsingEventStream.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/ParsingEventStream.cs
@@ -74,7 +74,7 @@ namespace YamlDotNet.Serialization
         /// <returns>A new <see cref="ParsingEventStream"/></returns>
         public static ParsingEventStream Create(IParser parser)
         {
-            LinkedList<ParsingEvent> events = new LinkedList<ParsingEvent>();
+            LinkedList<ParsingEvent> events = new();
             events.AddLast(parser.Consume<MappingStart>());
             var depth = 0;
             do

--- a/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/Yaml.cs
+++ b/src/ServerlessWorkflow.Sdk/Serialization/YamlDotNet/Yaml.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Serialization
+{
+    public static class Yaml
+    {
+
+        public static Action<SerializerBuilder> SerializerConfiguration
+        {
+            set
+            {
+                var builder = new SerializerBuilder();
+                value(builder);
+                Serializer = builder.Build();
+            }
+        }
+
+        public static Action<DeserializerBuilder> DeserializerConfiguration
+        {
+            set
+            {
+                var builder = new DeserializerBuilder();
+                value(builder);
+                Deserializer = builder.Build();
+            }
+        }
+
+        private static ISerializer Serializer;
+        private static IDeserializer Deserializer;
+
+        public static object Deserialize(IParser reader, Type expectedType)
+        {
+            return Deserializer.Deserialize(reader, expectedType);
+        }
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
-    <AssemblyVersion>0.7.4.2</AssemblyVersion>
-    <FileVersion>0.7.4.2</FileVersion>
-    <Version>0.7.4.2</Version>
+    <AssemblyVersion>0.7.4.3</AssemblyVersion>
+    <FileVersion>0.7.4.3</FileVersion>
+    <Version>0.7.4.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
     <AssemblyVersion>0.7.4.4</AssemblyVersion>
     <FileVersion>0.7.4.4</FileVersion>
@@ -37,15 +37,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CloudNative.CloudEvents" Version="1.3.80" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.5.4" />
+    <PackageReference Include="CloudNative.CloudEvents" Version="2.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
     <PackageReference Include="Iso8601DurationHelper" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Neuroglia.Serialization.Protobuf" Version="2.0.1.25" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Include="YamlDotNet" Version="10.1.0" />
+    <PackageReference Include="protobuf-net.Core" Version="3.0.101" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
-    <AssemblyVersion>0.7.4.3</AssemblyVersion>
-    <FileVersion>0.7.4.3</FileVersion>
-    <Version>0.7.4.3</Version>
+    <AssemblyVersion>0.7.4.4</AssemblyVersion>
+    <FileVersion>0.7.4.4</FileVersion>
+    <Version>0.7.4.4</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -1023,6 +1023,49 @@
             Gets the second possible value
             </summary>
         </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OneOf`2.op_Implicit(`0)~ServerlessWorkflow.Sdk.Models.OneOf{`0,`1}">
+            <summary>
+            Implicitly convert the specified value into a new <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/>
+            </summary>
+            <param name="value">The value to convert</param>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OneOf`2.op_Implicit(`1)~ServerlessWorkflow.Sdk.Models.OneOf{`0,`1}">
+            <summary>
+            Implicitly convert the specified value into a new <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/>
+            </summary>
+            <param name="value">The value to convert</param>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OneOf`2.op_Implicit(ServerlessWorkflow.Sdk.Models.OneOf{`0,`1})~`0">
+            <summary>
+            Implicitly convert the specified <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> into a new value
+            </summary>
+            <param name="value">The <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> to convert</param>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OneOf`2.op_Implicit(ServerlessWorkflow.Sdk.Models.OneOf{`0,`1})~`1">
+            <summary>
+            Implicitly convert the specified <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> into a new value
+            </summary>
+            <param name="value">The <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> to convert</param>
+        </member>
+        <member name="T:ServerlessWorkflow.Sdk.Models.Any">
+            <summary>
+            Represents an object of any type
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.Any.Fields">
+            <inheritdoc/>
+        </member>
+        <member name="T:ServerlessWorkflow.Sdk.Models.AnyConverter">
+            <summary>
+            Represents the <see cref="T:Newtonsoft.Json.JsonConverter"/> used to convert from and to <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/> instances
+            </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.AnyConverter.ReadJson(Newtonsoft.Json.JsonReader,System.Type,ServerlessWorkflow.Sdk.Models.Any,System.Boolean,Newtonsoft.Json.JsonSerializer)">
+            <inheritdoc/>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.AnyConverter.WriteJson(Newtonsoft.Json.JsonWriter,ServerlessWorkflow.Sdk.Models.Any,Newtonsoft.Json.JsonSerializer)">
+            <inheritdoc/>
+        </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.OperationStateDefinition">
             <summary>
             Represents a workflow state that defines a set of actions to be performed in sequence or in parallel. Once all actions have been performed, a transition to another state can occur.
@@ -5529,7 +5572,7 @@
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.Validation.CollectionPropertyValidator`1">
             <summary>
-            Represents the service used to validate a workflow's <see cref="T:ServerlessWorkflow.Sdk.Models.RetryStrategyDefinition"/>s
+            Represents the service used to validate a workflow's <see cref="T:System.Collections.Generic.ICollection`1"/>s
             </summary>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.Validation.CollectionPropertyValidator`1.#ctor(System.IServiceProvider)">
@@ -5538,12 +5581,15 @@
             </summary>
             <param name="serviceProvider">The current <see cref="T:System.IServiceProvider"/></param>
         </member>
+        <member name="P:ServerlessWorkflow.Sdk.Services.Validation.CollectionPropertyValidator`1.Name">
+            <inheritdoc/>
+        </member>
         <member name="P:ServerlessWorkflow.Sdk.Services.Validation.CollectionPropertyValidator`1.ServiceProvider">
             <summary>
             Gets the current <see cref="T:System.IServiceProvider"/>
             </summary>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.CollectionPropertyValidator`1.IsValid(FluentValidation.Validators.PropertyValidatorContext)">
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.CollectionPropertyValidator`1.IsValid(FluentValidation.ValidationContext{ServerlessWorkflow.Sdk.Models.WorkflowDefinition},System.Collections.Generic.IEnumerable{`0})">
             <inheritdoc/>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.Validation.DataCaseDefinitionValidator">
@@ -5710,7 +5756,10 @@
             Represents the <see cref="T:FluentValidation.Validators.PropertyValidator"/> used to validate a <see cref="T:ServerlessWorkflow.Sdk.Models.FunctionDefinition"/> collection
             </summary>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.FunctionDefinitionCollectionValidator.IsValid(FluentValidation.Validators.PropertyValidatorContext)">
+        <member name="P:ServerlessWorkflow.Sdk.Services.Validation.FunctionDefinitionCollectionValidator.Name">
+            <inheritdoc/>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.FunctionDefinitionCollectionValidator.IsValid(FluentValidation.ValidationContext{ServerlessWorkflow.Sdk.Models.WorkflowDefinition},System.Collections.Generic.IEnumerable{ServerlessWorkflow.Sdk.Models.FunctionDefinition})">
             <inheritdoc/>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.Validation.FunctionDefinitionValidator">
@@ -5986,7 +6035,7 @@
             Gets the current <see cref="T:System.IServiceProvider"/>
             </summary>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.WorkflowStatesPropertyValidator.IsValid(FluentValidation.Validators.PropertyValidatorContext)">
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.WorkflowStatesPropertyValidator.IsValid(FluentValidation.ValidationContext{ServerlessWorkflow.Sdk.Models.WorkflowDefinition},System.Collections.Generic.List{ServerlessWorkflow.Sdk.Models.StateDefinition})">
             <inheritdoc/>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.StateType">
@@ -6473,6 +6522,39 @@
             <param name="stream">The <see cref="T:YamlDotNet.Serialization.ParsingEventStream"/> to use to resolve the implementation type</param>
             <param name="implementationType">The resulting implementation type</param>
             <returns>A boolean indicating whether or not the implementation type could be resolved thanks to the specified <see cref="T:YamlDotNet.Serialization.ParsingEventStream"/></returns>
+        </member>
+        <member name="T:YamlDotNet.Serialization.AnyConverter">
+            <summary>
+            Represents the <see cref="T:YamlDotNet.Serialization.IYamlTypeConverter"/> used to serialize and deserialize <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/> instances
+            </summary>
+        </member>
+        <member name="M:YamlDotNet.Serialization.AnyConverter.Accepts(System.Type)">
+            <inheritdoc/>
+        </member>
+        <member name="M:YamlDotNet.Serialization.AnyConverter.ReadYaml(YamlDotNet.Core.IParser,System.Type)">
+            <inheritdoc/>
+        </member>
+        <member name="M:YamlDotNet.Serialization.AnyConverter.WriteYaml(YamlDotNet.Core.IEmitter,System.Object,System.Type)">
+            <inheritdoc/>
+        </member>
+        <member name="T:YamlDotNet.Serialization.AnyDeserializer">
+            <summary>
+            Represents an <see cref="T:YamlDotNet.Serialization.INodeDeserializer"/> used to deserialize <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/> instances
+            </summary>
+        </member>
+        <member name="M:YamlDotNet.Serialization.AnyDeserializer.#ctor(YamlDotNet.Serialization.INodeDeserializer)">
+            <summary>
+            Initializes a new <see cref="T:YamlDotNet.Serialization.AnyDeserializer"/>
+            </summary>
+            <param name="inner">The inner <see cref="T:YamlDotNet.Serialization.INodeDeserializer"/></param>
+        </member>
+        <member name="P:YamlDotNet.Serialization.AnyDeserializer.Inner">
+            <summary>
+            Gets the inner <see cref="T:YamlDotNet.Serialization.INodeDeserializer"/>
+            </summary>
+        </member>
+        <member name="M:YamlDotNet.Serialization.AnyDeserializer.Deserialize(YamlDotNet.Core.IParser,System.Type,System.Func{YamlDotNet.Core.IParser,System.Type,System.Object},System.Object@)">
+            <inheritdoc/>
         </member>
         <member name="T:YamlDotNet.Serialization.ChainedObjectGraphVisitor">
             <summary>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -185,6 +185,29 @@
             Gets/sets an <see cref="T:System.Collections.Generic.List`1"/> containing the actions to be executed in this branch
             </summary>
         </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.BranchDefinition.GetAction(System.String)">
+            <summary>
+            Gets the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get</param>
+            <returns>The <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.BranchDefinition.TryGetAction(System.String,ServerlessWorkflow.Sdk.Models.ActionDefinition@)">
+            <summary>
+            Attempts to get the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get</param>
+            <param name="action">The <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name</param>
+            <returns>A boolean indicating whether or not a <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name could be found</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.BranchDefinition.TryGetNextAction(System.String,ServerlessWorkflow.Sdk.Models.ActionDefinition@)">
+            <summary>
+            Attempts to get the next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> in the pipeline
+            </summary>
+            <param name="previousActionName">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get the next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> for</param>
+            <param name="action">The next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/>, if any</param>
+            <returns>A boolean indicating whether or not there is a next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> in the pipeline</returns>
+        </member>
         <member name="M:ServerlessWorkflow.Sdk.Models.BranchDefinition.ToString">
             <inheritdoc/>
         </member>
@@ -966,6 +989,40 @@
             Gets the $schemaversion system query option, which allows clients to specify the version of the schema against which the request is made. The semantics of $schemaversion is covered in the OData-Protocol (http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#odata) document
             </summary>
         </member>
+        <member name="T:ServerlessWorkflow.Sdk.Models.OneOf`2">
+            <summary>
+            Gets an object that is one of the specified types
+            </summary>
+            <typeparam name="T1">A first type alternative</typeparam>
+            <typeparam name="T2">A second type alternative</typeparam>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OneOf`2.#ctor">
+            <summary>
+            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/>
+            </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OneOf`2.#ctor(`0)">
+            <summary>
+            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/>
+            </summary>
+            <param name="value">The value of the <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/></param>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OneOf`2.#ctor(`1)">
+            <summary>
+            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/>
+            </summary>
+            <param name="value">The value of the <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/></param>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.OneOf`2.Value1">
+            <summary>
+            Gets the first possible value
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.OneOf`2.Value2">
+            <summary>
+            Gets the second possible value
+            </summary>
+        </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.OperationStateDefinition">
             <summary>
             Represents a workflow state that defines a set of actions to be performed in sequence or in parallel. Once all actions have been performed, a transition to another state can occur.
@@ -1285,7 +1342,7 @@
             Gets/sets the id of the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> used to compensate the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.UseForCompensation">
+        <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.UsedForCompensation">
             <summary>
             Gets/sets a boolean indicating whether or not the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> is used for compensating another <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>
             </summary>
@@ -2057,6 +2114,26 @@
         <member name="P:ServerlessWorkflow.Sdk.Serialization.DiscriminatorValueAttribute.Value">
             <summary>
             Gets the value used to discriminate the derived type marked by the <see cref="T:ServerlessWorkflow.Sdk.Serialization.DiscriminatorValueAttribute"/>
+            </summary>
+        </member>
+        <member name="T:ServerlessWorkflow.Sdk.ServerlessWorkflowSpecVersion">
+            <summary>
+            Exposes all supported Serverless Workflow spec versions
+            </summary>
+        </member>
+        <member name="F:ServerlessWorkflow.Sdk.ServerlessWorkflowSpecVersion.Latest">
+            <summary>
+            Gets the latest supported spec version
+            </summary>
+        </member>
+        <member name="F:ServerlessWorkflow.Sdk.ServerlessWorkflowSpecVersion.V0_6">
+            <summary>
+            Gets the v0.6.x version
+            </summary>
+        </member>
+        <member name="F:ServerlessWorkflow.Sdk.ServerlessWorkflowSpecVersion.V0_7">
+            <summary>
+            Gets the v0.7.x version
             </summary>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.FluentBuilders.ActionBuilder">
@@ -4821,13 +4898,22 @@
             Defines the fundamentals of a service used to validate <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>s
             </summary>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.IO.IWorkflowSchemaValidator.Validate(System.String,System.Collections.Generic.IList{System.String}@)">
+        <member name="M:ServerlessWorkflow.Sdk.Services.IO.IWorkflowSchemaValidator.ValidateAsync(ServerlessWorkflow.Sdk.Models.WorkflowDefinition,System.Threading.CancellationToken)">
+            <summary>
+            Validates the specified <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>
+            </summary>
+            <param name="workflow">The input to validate</param>
+            <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken"/></param>
+            <returns>An <see cref="T:System.Collections.Generic.IList`1"/> containing the <see cref="T:Newtonsoft.Json.Schema.ValidationError"/>s that have occured</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Services.IO.IWorkflowSchemaValidator.ValidateAsync(System.String,System.String,System.Threading.CancellationToken)">
             <summary>
             Validates the specified JSON input
             </summary>
             <param name="json">The input to validate</param>
-            <param name="errors">An <see cref="T:System.Collections.Generic.IList`1"/> containing the validation errors key/value pairs</param>
-            <returns>A boolean indicating whether or not the specified JSON input is a valid <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/></returns>
+            <param name="specVersion">The Serverless Workflow spec version to evaluate the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/> against</param>
+            <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken"/></param>
+            <returns>An <see cref="T:System.Collections.Generic.IList`1"/> containing the <see cref="T:Newtonsoft.Json.Schema.ValidationError"/>s that have occured</returns>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.IO.IWorkflowWriter">
             <summary>
@@ -4947,15 +5033,18 @@
             Gets the <see cref="T:System.Net.Http.HttpClient"/> used to fetch the Serverless Workflow schema
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Services.IO.WorkflowSchemaValidator.Schema">
+        <member name="P:ServerlessWorkflow.Sdk.Services.IO.WorkflowSchemaValidator.Schemas">
             <summary>
-            Gets the <see cref="T:Newtonsoft.Json.Schema.JSchema"/> used to validate <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>s
+            Gets a <see cref="T:System.Collections.Generic.Dictionary`2"/> containing the loaded Serverless Workflow spec <see cref="T:Newtonsoft.Json.Schema.JSchema"/>s
             </summary>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.IO.WorkflowSchemaValidator.Validate(System.String,System.Collections.Generic.IList{System.String}@)">
+        <member name="M:ServerlessWorkflow.Sdk.Services.IO.WorkflowSchemaValidator.ValidateAsync(System.String,System.String,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.IO.WorkflowSchemaValidator.LoadSchemaAsync">
+        <member name="M:ServerlessWorkflow.Sdk.Services.IO.WorkflowSchemaValidator.ValidateAsync(ServerlessWorkflow.Sdk.Models.WorkflowDefinition,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Services.IO.WorkflowSchemaValidator.LoadSchemaAsync(System.String,System.Threading.CancellationToken)">
             <summary>
             Loads the Serverless Workflow <see cref="T:Newtonsoft.Json.Schema.JSchema"/>
             </summary>
@@ -6091,6 +6180,19 @@
         <member name="M:System.Text.Json.Serialization.Converters.Iso8601TimeSpanConverter.Write(System.Text.Json.Utf8JsonWriter,System.Nullable{System.TimeSpan},System.Text.Json.JsonSerializerOptions)">
             <inheritdoc/>
         </member>
+        <member name="T:System.Text.Json.Serialization.Converters.OneOfConverter`2">
+            <summary>
+            Represents the service used to convert <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/>
+            </summary>
+            <typeparam name="T1">The first type alternative</typeparam>
+            <typeparam name="T2">The second type alternative</typeparam>
+        </member>
+        <member name="M:System.Text.Json.Serialization.Converters.OneOfConverter`2.Read(System.Text.Json.Utf8JsonReader@,System.Type,System.Text.Json.JsonSerializerOptions)">
+            <inheritdoc/>
+        </member>
+        <member name="M:System.Text.Json.Serialization.Converters.OneOfConverter`2.Write(System.Text.Json.Utf8JsonWriter,ServerlessWorkflow.Sdk.Models.OneOf{`0,`1},System.Text.Json.JsonSerializerOptions)">
+            <inheritdoc/>
+        </member>
         <member name="T:System.Text.Json.Serialization.Converters.StringEnumConverter`1">
             <summary>
             Represents the <see cref="T:System.Text.Json.Serialization.JsonConverter`1"/> used to convert from and to <see cref="T:System.Enum"/>s
@@ -6206,6 +6308,27 @@
         <member name="M:System.Text.Json.Serialization.Converters.StringEnumConverterFactory.CreateConverter(System.Type,System.Text.Json.JsonSerializerOptions)">
             <inheritdoc/>
         </member>
+        <member name="T:System.Text.Json.Serialization.JsonElementExtensions">
+            <summary>
+            Defines extensions for <see cref="T:System.Text.Json.JsonElement"/>s
+            </summary>
+        </member>
+        <member name="M:System.Text.Json.Serialization.JsonElementExtensions.ToObject``1(System.Text.Json.JsonElement)">
+            <summary>
+            Converts the <see cref="T:System.Text.Json.JsonElement"/> into a new object of the specified type
+            </summary>
+            <typeparam name="T">The type of object to convert the <see cref="T:System.Text.Json.JsonElement"/> into</typeparam>
+            <param name="element">The <see cref="T:System.Text.Json.JsonElement"/> to convert</param>
+            <returns>A new object of the specified type</returns>
+        </member>
+        <member name="M:System.Text.Json.Serialization.JsonElementExtensions.ToObject``1(System.Text.Json.JsonDocument)">
+            <summary>
+            Converts the <see cref="T:System.Text.Json.JsonDocument"/> into a new object of the specified type
+            </summary>
+            <typeparam name="T">The type of object to convert the <see cref="T:System.Text.Json.JsonDocument"/> into</typeparam>
+            <param name="document">The <see cref="T:System.Text.Json.JsonDocument"/> to convert</param>
+            <returns>A new object of the specified type</returns>
+        </member>
         <member name="T:Newtonsoft.Json.Converters.AbstractClassConverter`1">
             <summary>
             Represents a <see cref="T:Newtonsoft.Json.JsonConverter"/> used to deserialize implementations of the specified abstract class
@@ -6270,6 +6393,19 @@
             <inheritdoc/>
         </member>
         <member name="M:Newtonsoft.Json.Converters.Iso8601TimeSpanConverter.WriteJson(Newtonsoft.Json.JsonWriter,System.TimeSpan,Newtonsoft.Json.JsonSerializer)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Newtonsoft.Json.Converters.OneOfConverter`2">
+            <summary>
+            Represents the service used to convert <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/>
+            </summary>
+            <typeparam name="T1">The first type alternative</typeparam>
+            <typeparam name="T2">The second type alternative</typeparam>
+        </member>
+        <member name="M:Newtonsoft.Json.Converters.OneOfConverter`2.ReadJson(Newtonsoft.Json.JsonReader,System.Type,ServerlessWorkflow.Sdk.Models.OneOf{`0,`1},System.Boolean,Newtonsoft.Json.JsonSerializer)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Newtonsoft.Json.Converters.OneOfConverter`2.WriteJson(Newtonsoft.Json.JsonWriter,ServerlessWorkflow.Sdk.Models.OneOf{`0,`1},Newtonsoft.Json.JsonSerializer)">
             <inheritdoc/>
         </member>
         <member name="T:Newtonsoft.Json.IgnoreEmptyEnumerableContractResolver">
@@ -6497,6 +6633,39 @@
             </summary>
         </member>
         <member name="M:YamlDotNet.Serialization.NonPublicConstructorObjectFactory.Create(System.Type)">
+            <inheritdoc/>
+        </member>
+        <member name="T:YamlDotNet.Serialization.OneOfConverter">
+            <summary>
+            Represents the <see cref="T:YamlDotNet.Serialization.IYamlTypeConverter"/> used to serialize and deserialize <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> instances
+            </summary>
+        </member>
+        <member name="M:YamlDotNet.Serialization.OneOfConverter.Accepts(System.Type)">
+            <inheritdoc/>
+        </member>
+        <member name="M:YamlDotNet.Serialization.OneOfConverter.ReadYaml(YamlDotNet.Core.IParser,System.Type)">
+            <inheritdoc/>
+        </member>
+        <member name="M:YamlDotNet.Serialization.OneOfConverter.WriteYaml(YamlDotNet.Core.IEmitter,System.Object,System.Type)">
+            <inheritdoc/>
+        </member>
+        <member name="T:YamlDotNet.Serialization.OneOfDeserializer">
+            <summary>
+            Represents an <see cref="T:YamlDotNet.Serialization.INodeDeserializer"/> used to deserialize <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> instances
+            </summary>
+        </member>
+        <member name="M:YamlDotNet.Serialization.OneOfDeserializer.#ctor(YamlDotNet.Serialization.INodeDeserializer)">
+            <summary>
+            Initializes a new <see cref="T:YamlDotNet.Serialization.OneOfDeserializer"/>
+            </summary>
+            <param name="inner">The inner <see cref="T:YamlDotNet.Serialization.INodeDeserializer"/></param>
+        </member>
+        <member name="P:YamlDotNet.Serialization.OneOfDeserializer.Inner">
+            <summary>
+            Gets the inner <see cref="T:YamlDotNet.Serialization.INodeDeserializer"/>
+            </summary>
+        </member>
+        <member name="M:YamlDotNet.Serialization.OneOfDeserializer.Deserialize(YamlDotNet.Core.IParser,System.Type,System.Func{YamlDotNet.Core.IParser,System.Type,System.Object},System.Object@)">
             <inheritdoc/>
         </member>
         <member name="T:YamlDotNet.Serialization.ParsingEventStream">

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -825,6 +825,86 @@
             Gets/sets the issuer that must generate a new token in return for the exchanged one
             </summary>
         </member>
+        <member name="T:ServerlessWorkflow.Sdk.Models.ODataCommandOptions">
+            <summary>
+            Represents the options used to configure an OData command
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataCommandOptions.Id">
+            <summary>
+            Gets the unique identifier of the single entry to query
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataCommandOptions.QueryOptions">
+            <summary>
+            Gets the options used to configure the OData query
+            </summary>
+        </member>
+        <member name="T:ServerlessWorkflow.Sdk.Models.ODataQueryOptions">
+            <summary>
+            Represents the options used to configure an OData query
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Filter">
+            <summary>
+            Gets the $filter system query option, which allows clients to filter the set of resources that are addressed by a request URL. $filter specifies conditions that MUST be met by a resource for it to be returned in the set of matching resources
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Expand">
+            <summary>
+            Gets the $expand system query option, which allows clients to request related resources when a resource that satifies a particular request is retrieved
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Select">
+            <summary>
+            Gets the $select system query option, which allows clients to requests a limited set of information for each entity or complex type identified by the ResourcePath and other System Query Options like $filter, $top, $skip etc. The $select query option is often used in conjunction with the $expand query option, to first increase the scope of the resource graph returned ($expand) and then selectively prune that resource graph ($select)
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.OrderBy">
+            <summary>
+            Gets the $orderby system query option, which allows clients to request resource in a particular order
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Top">
+            <summary>
+            Gets the $top system query option, which allows clients a required number of resources. Usually used in conjunction with the $skip query options
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Skip">
+            <summary>
+            Gets the $skip system query option, which allows clients to skip a given number of resources. Usually used in conjunction with the $top query options
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Count">
+            <summary>
+            Gets the $count system query option, which allows clients to request a count of the matching resources included with the resources in the response
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Search">
+            <summary>
+            Gets the $search system query option, which allows clients to request items within a collection matching a free-text search expression
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Format">
+            <summary>
+            Gets the $format system query option, if supported, which allows clients to request a response in a particular format
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Compute">
+            <summary>
+            Gets the $compute system query option, which allows clients to define computed properties that can be used in a $select or within a $filter or $orderby expression
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.Index">
+            <summary>
+            Gets the $index system query option, which allows clients to do a positional insert into a collection annotated with using the Core.PositionalInsert term (see http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#VocCore)
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataQueryOptions.SchemaVersion">
+            <summary>
+            Gets the $schemaversion system query option, which allows clients to specify the version of the schema against which the request is made. The semantics of $schemaversion is covered in the OData-Protocol (http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#odata) document
+            </summary>
+        </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.OperationStateDefinition">
             <summary>
             Represents a workflow state that defines a set of actions to be performed in sequence or in parallel. Once all actions have been performed, a transition to another state can occur.

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -830,7 +830,7 @@
             Represents the options used to configure an OData command
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.ODataCommandOptions.Id">
+        <member name="P:ServerlessWorkflow.Sdk.Models.ODataCommandOptions.Key">
             <summary>
             Gets the unique identifier of the single entry to query
             </summary>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -64,11 +64,6 @@
             Gets the object used to configure the reference of the function to invoke
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.ActionDefinition.EventToken">
-            <summary>
-            Gets/sets a <see cref="T:Newtonsoft.Json.Linq.JToken"/> that references a 'trigger' and 'result' reusable event definitions
-            </summary>
-        </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.ActionDefinition.Event">
             <summary>
             Gets the object used to configure the reference of the event to produce or consume
@@ -95,6 +90,25 @@
             </summary>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Models.ActionDefinition.ToString">
+            <inheritdoc/>
+        </member>
+        <member name="T:ServerlessWorkflow.Sdk.Models.Any">
+            <summary>
+            Represents an object of any type
+            </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.Any.#ctor">
+            <summary>
+            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/>
+            </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.Any.#ctor(System.Collections.Generic.IDictionary{System.String,System.Object})">
+            <summary>
+            Innitializes a new <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/>
+            </summary>
+            <param name="properties">An <see cref="T:System.Collections.Generic.IDictionary`2"/> containing the <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/>'s name/value property mappings</param>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.Any.Fields">
             <inheritdoc/>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.AuthenticationDefinition">
@@ -281,44 +295,29 @@
             Gets/sets a boolean indicating whether or not to terminate the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s execution whenever the validation of the input data fails. Defaults to true.
             </summary>
         </member>
-        <member name="T:ServerlessWorkflow.Sdk.Models.DefaultDefinition">
+        <member name="T:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition">
             <summary>
             Represents an object used to define the transition of the workflow if there is no matching data conditions or event timeout is reached
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultDefinition.TransitionToken">
+        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.TransitionToken">
             <summary>
             Gets/sets a <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the next transition of the workflow if there is valid matches
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultDefinition.Transition">
+        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.Transition">
             <summary>
             Gets/sets an object used to define the next transition of the workflow if there is valid matches
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultDefinition.EndToken">
+        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.EndToken">
             <summary>
             Gets/sets a <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the object used to configure the end of the workflow
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultDefinition.End">
+        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.End">
             <summary>
             Gets/sets an object used to configure the end of the workflow
-            </summary>
-        </member>
-        <member name="T:ServerlessWorkflow.Sdk.Models.DelayStateDefinition">
-            <summary>
-            Represents a workflow state that waits for a certain amount of time before transitioning to a next state
-            </summary>
-        </member>
-        <member name="M:ServerlessWorkflow.Sdk.Models.DelayStateDefinition.#ctor">
-            <summary>
-            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Models.DelayStateDefinition"/>
-            </summary>
-        </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.DelayStateDefinition.Delay">
-            <summary>
-            Gets/sets the amount of time to delay when in this state
             </summary>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.EndDefinition">
@@ -823,7 +822,7 @@
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.FunctionReference.Arguments">
             <summary>
-            Gets/sets a <see cref="T:Newtonsoft.Json.Linq.JObject"/> that contains the parameters of the function to invoke
+            Gets/sets a <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/> that contains the parameters of the function to invoke
             </summary>
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.FunctionReference.SelectionSet">
@@ -846,7 +845,7 @@
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.InjectStateDefinition.Data">
             <summary>
-            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> which can be set as state's data input and can be manipulated via filter
+            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/> which can be set as state's data input and can be manipulated via filter
             </summary>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.OAuth2AuthenticationProperties">
@@ -1047,25 +1046,6 @@
             </summary>
             <param name="value">The <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> to convert</param>
         </member>
-        <member name="T:ServerlessWorkflow.Sdk.Models.Any">
-            <summary>
-            Represents an object of any type
-            </summary>
-        </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.Any.Fields">
-            <inheritdoc/>
-        </member>
-        <member name="T:ServerlessWorkflow.Sdk.Models.AnyConverter">
-            <summary>
-            Represents the <see cref="T:Newtonsoft.Json.JsonConverter"/> used to convert from and to <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/> instances
-            </summary>
-        </member>
-        <member name="M:ServerlessWorkflow.Sdk.Models.AnyConverter.ReadJson(Newtonsoft.Json.JsonReader,System.Type,ServerlessWorkflow.Sdk.Models.Any,System.Boolean,Newtonsoft.Json.JsonSerializer)">
-            <inheritdoc/>
-        </member>
-        <member name="M:ServerlessWorkflow.Sdk.Models.AnyConverter.WriteJson(Newtonsoft.Json.JsonWriter,ServerlessWorkflow.Sdk.Models.Any,Newtonsoft.Json.JsonSerializer)">
-            <inheritdoc/>
-        </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.OperationStateDefinition">
             <summary>
             Represents a workflow state that defines a set of actions to be performed in sequence or in parallel. Once all actions have been performed, a transition to another state can occur.
@@ -1238,11 +1218,6 @@
             Gets/sets a CRON expression that defines when the workflow instance should be created
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.ScheduleDefinition.DirectInvoke">
-            <summary>
-            Gets/sets a boolean indicating whether or not workflow instances can be created outside of the defined interval/cron. Defaults to false.
-            </summary>
-        </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.ScheduleDefinition.Timezone">
             <summary>
             Gets/sets the timezone name used to evaluate the cron expression. Not used for interval as timezone can be specified there directly. If not specified, should default to local machine timezone.
@@ -1267,6 +1242,21 @@
         <member name="P:ServerlessWorkflow.Sdk.Models.SecretBasedAuthenticationProperties.Secret">
             <summary>
             Gets the name of the secret to load the <see cref="T:ServerlessWorkflow.Sdk.Models.SecretBasedAuthenticationProperties"/> from
+            </summary>
+        </member>
+        <member name="T:ServerlessWorkflow.Sdk.Models.SleepStateDefinition">
+            <summary>
+            Represents a workflow state that waits for a certain amount of time before transitioning to a next state
+            </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.SleepStateDefinition.#ctor">
+            <summary>
+            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Models.SleepStateDefinition"/>
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.SleepStateDefinition.Delay">
+            <summary>
+            Gets/sets the amount of time to delay when in this state
             </summary>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.StartDefinition">
@@ -2068,6 +2058,17 @@
             Indicates an expression function
             </summary>
         </member>
+        <member name="T:ServerlessWorkflow.Sdk.IOneOf">
+            <summary>
+            Defines the fundamentals of a service that wraps around multiple alternative value types
+            </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.IOneOf.GetValue">
+            <summary>
+            Gets the object's current value
+            </summary>
+            <returns>The object's current value</returns>
+        </member>
         <member name="T:ServerlessWorkflow.Sdk.Iso8601TimeSpan">
             <summary>
             Represents an helper class for handling ISO 8601 timespans
@@ -2240,6 +2241,9 @@
             <inheritdoc/>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.FluentBuilders.ActionBuilder.ThenProduce(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Services.FluentBuilders.ActionBuilder.ThenProduce(System.Action{ServerlessWorkflow.Sdk.Services.FluentBuilders.IEventBuilder})">
             <inheritdoc/>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.FluentBuilders.ActionBuilder.WithContextAttribute(System.String,System.String)">
@@ -3073,7 +3077,7 @@
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.FluentBuilders.IDelayStateBuilder">
             <summary>
-            Defines the fundamentals of a service used to build <see cref="T:ServerlessWorkflow.Sdk.Models.DelayStateDefinition"/>s
+            Defines the fundamentals of a service used to build <see cref="T:ServerlessWorkflow.Sdk.Models.SleepStateDefinition"/>s
             </summary>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.FluentBuilders.IDelayStateBuilder.For(System.TimeSpan)">
@@ -3333,6 +3337,13 @@
             </summary>
             <param name="e">The reference name of the <see cref="T:ServerlessWorkflow.Sdk.Models.EventDefinition"/> to produce. Requires the referenced <see cref="T:ServerlessWorkflow.Sdk.Models.EventDefinition"/> to have been previously defined.</param>
             <returns>The configured <see cref="T:ServerlessWorkflow.Sdk.Services.FluentBuilders.IEventTriggerActionBuilder"/></returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Services.FluentBuilders.IEventTriggerActionBuilder.ThenProduce(System.Action{ServerlessWorkflow.Sdk.Services.FluentBuilders.IEventBuilder})">
+            <summary>
+            Configures the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to produce the specified <see cref="T:ServerlessWorkflow.Sdk.Models.EventDefinition"/> when triggered
+            </summary>
+            <param name="eventSetup">The <see cref="T:System.Action`1"/> used to create the <see cref="T:ServerlessWorkflow.Sdk.Models.EventDefinition"/> to produce</param>
+            <returns>The configured <see cref="T:ServerlessWorkflow.Sdk.Services.FluentBuilders.IActionBuilder"/></returns>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.FluentBuilders.IEventTriggerActionBuilder.WithContextAttribute(System.String,System.String)">
             <summary>
@@ -3942,14 +3953,14 @@
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.FluentBuilders.IStateBuilderFactory.Delay(System.TimeSpan)">
             <summary>
-            Creates and configures a new <see cref="T:ServerlessWorkflow.Sdk.Models.DelayStateDefinition"/>
+            Creates and configures a new <see cref="T:ServerlessWorkflow.Sdk.Models.SleepStateDefinition"/>
             </summary>
             <param name="duration">The delay's duration</param>
             <returns>A new <see cref="T:ServerlessWorkflow.Sdk.Services.FluentBuilders.IDelayStateBuilder"/></returns>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.FluentBuilders.IStateBuilderFactory.Delay">
             <summary>
-            Creates and configures a new <see cref="T:ServerlessWorkflow.Sdk.Models.DelayStateDefinition"/>
+            Creates and configures a new <see cref="T:ServerlessWorkflow.Sdk.Models.SleepStateDefinition"/>
             </summary>
             <returns>A new <see cref="T:ServerlessWorkflow.Sdk.Services.FluentBuilders.IDelayStateBuilder"/></returns>
         </member>
@@ -5604,17 +5615,6 @@
             <param name="workflow">The <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/> the <see cref="T:ServerlessWorkflow.Sdk.Models.DataCaseDefinition"/> to validate belongs to</param>
             <param name="state">The <see cref="T:ServerlessWorkflow.Sdk.Models.SwitchStateDefinition"/> the <see cref="T:ServerlessWorkflow.Sdk.Models.DataCaseDefinition"/> to validate belongs to</param>
         </member>
-        <member name="T:ServerlessWorkflow.Sdk.Services.Validation.DelayStateValidator">
-            <summary>
-            Represents a service used to validate <see cref="T:ServerlessWorkflow.Sdk.Models.DelayStateDefinition"/>s
-            </summary>
-        </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.DelayStateValidator.#ctor(ServerlessWorkflow.Sdk.Models.WorkflowDefinition)">
-            <summary>
-            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Services.Validation.DelayStateValidator"/>
-            </summary>
-            <param name="workflow">The <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/> to validate</param>
-        </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.Validation.ErrorHandlerDefinitionValidator">
             <summary>
             Represents the service used to validate <see cref="T:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition"/>s
@@ -5864,6 +5864,17 @@
             Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Services.Validation.RetryStrategyDefinitionValidator"/>
             </summary>
         </member>
+        <member name="T:ServerlessWorkflow.Sdk.Services.Validation.SleepStateValidator">
+            <summary>
+            Represents a service used to validate <see cref="T:ServerlessWorkflow.Sdk.Models.SleepStateDefinition"/>s
+            </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.SleepStateValidator.#ctor(ServerlessWorkflow.Sdk.Models.WorkflowDefinition)">
+            <summary>
+            Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Services.Validation.SleepStateValidator"/>
+            </summary>
+            <param name="workflow">The <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/> to validate</param>
+        </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1">
             <summary>
             Represents the base class for all <see cref="T:FluentValidation.IValidator"/>s used to validate <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>s
@@ -6048,9 +6059,9 @@
             Indicates an operation state
             </summary>
         </member>
-        <member name="F:ServerlessWorkflow.Sdk.StateType.Delay">
+        <member name="F:ServerlessWorkflow.Sdk.StateType.Sleep">
             <summary>
-            Indicates a delay state
+            Indicates a sleep state
             </summary>
         </member>
         <member name="F:ServerlessWorkflow.Sdk.StateType.Event">
@@ -6431,6 +6442,17 @@
             <inheritdoc/>
         </member>
         <member name="M:Newtonsoft.Json.Converters.AbstractClassConverterFactory.WriteJson(Newtonsoft.Json.JsonWriter,System.Object,Newtonsoft.Json.JsonSerializer)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Newtonsoft.Json.Converters.AnyConverter">
+            <summary>
+            Represents the <see cref="T:Newtonsoft.Json.JsonConverter"/> used to convert from and to <see cref="T:ServerlessWorkflow.Sdk.Models.Any"/> instances
+            </summary>
+        </member>
+        <member name="M:Newtonsoft.Json.Converters.AnyConverter.ReadJson(Newtonsoft.Json.JsonReader,System.Type,ServerlessWorkflow.Sdk.Models.Any,System.Boolean,Newtonsoft.Json.JsonSerializer)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Newtonsoft.Json.Converters.AnyConverter.WriteJson(Newtonsoft.Json.JsonWriter,ServerlessWorkflow.Sdk.Models.Any,Newtonsoft.Json.JsonSerializer)">
             <inheritdoc/>
         </member>
         <member name="T:Newtonsoft.Json.Converters.Iso8601TimeSpanConverter">

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -1588,19 +1588,9 @@
             Gets/sets the object used to configure the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s execution timeout
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.WorkflowDefinition.StartToken">
-            <summary>
-            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that defines the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s start
-            </summary>
-        </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.WorkflowDefinition.Start">
             <summary>
-            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.StartDefinition"/>
-            </summary>
-        </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.WorkflowDefinition.StartState">
-            <summary>
-            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s start <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>. If not set, defaults to the first defined <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>
+            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that defines the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s start
             </summary>
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.WorkflowDefinition.KeepActive">
@@ -5987,13 +5977,13 @@
         <member name="M:ServerlessWorkflow.Sdk.Services.Validation.WorkflowDefinitionValidator.Validate(FluentValidation.ValidationContext{ServerlessWorkflow.Sdk.Models.WorkflowDefinition})">
             <inheritdoc/>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.WorkflowDefinitionValidator.ReferenceExistingState(ServerlessWorkflow.Sdk.Models.WorkflowDefinition,ServerlessWorkflow.Sdk.Models.StartDefinition)">
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.WorkflowDefinitionValidator.ReferenceExistingState(ServerlessWorkflow.Sdk.Models.WorkflowDefinition,ServerlessWorkflow.Sdk.Models.OneOf{ServerlessWorkflow.Sdk.Models.StartDefinition,System.String})">
             <summary>
-            Determines whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StartDefinition"/> defines an existing <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>
+            Determines whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StartDefinition"/> references an existing <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>
             </summary>
             <param name="workflow">The <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/> to validate</param>
-            <param name="start">The <see cref="T:ServerlessWorkflow.Sdk.Models.StartDefinition"/> to validate</param>
-            <returns>A boolean indicating whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StartDefinition"/> defines an existing <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/></returns>
+            <param name="oneOf">The <see cref="T:ServerlessWorkflow.Sdk.Models.StartDefinition"/> to check</param>
+            <returns>A boolean indicating whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> exists</returns>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Services.Validation.WorkflowStatesPropertyValidator">
             <summary>
@@ -6005,6 +5995,9 @@
             Initializes a new <see cref="T:ServerlessWorkflow.Sdk.Services.Validation.WorkflowStatesPropertyValidator"/>
             </summary>
             <param name="serviceProvider">The current <see cref="T:System.IServiceProvider"/></param>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Services.Validation.WorkflowStatesPropertyValidator.Name">
+            <inheritdoc/>
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Services.Validation.WorkflowStatesPropertyValidator.ServiceProvider">
             <summary>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -300,24 +300,14 @@
             Represents an object used to define the transition of the workflow if there is no matching data conditions or event timeout is reached
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.TransitionToken">
+        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.Transition">
             <summary>
             Gets/sets a <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the next transition of the workflow if there is valid matches
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.Transition">
-            <summary>
-            Gets/sets an object used to define the next transition of the workflow if there is valid matches
-            </summary>
-        </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.EndToken">
-            <summary>
-            Gets/sets a <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the object used to configure the end of the workflow
-            </summary>
-        </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.DefaultConditionDefinition.End">
             <summary>
-            Gets/sets an object used to configure the end of the workflow
+            Gets/sets a <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the object used to configure the end of the workflow
             </summary>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.EndDefinition">
@@ -360,24 +350,14 @@
             Gets/sets a reference to the <see cref="T:ServerlessWorkflow.Sdk.Models.RetryStrategyDefinition"/> to use 
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition.TransitionToken">
+        <member name="P:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition.Transition">
             <summary>
             Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/>
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition.Transition">
-            <summary>
-            Gets/sets the object used to configre the transition to execute on error.
-            </summary>
-        </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition.EndToken">
-            <summary>
-            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/>
-            </summary>
-        </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition.End">
             <summary>
-            Gets/sets the object used to configre the way the workflow ends on error
+            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/>
             </summary>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Models.ErrorHandlerDefinition.ToString">
@@ -1266,7 +1246,7 @@
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.StartDefinition.StateName">
             <summary>
-            Gets/sets the name of the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s start <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>
+            Gets/sets the name of the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s start <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>. If not defined, defaults to the first defined state
             </summary>
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.StartDefinition.Schedule">
@@ -1330,14 +1310,9 @@
             Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s id
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.EndToken">
-            <summary>
-            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/>
-            </summary>
-        </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.End">
             <summary>
-            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/>
+            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/>
             </summary>
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.DataFilter">
@@ -1350,14 +1325,9 @@
             Gets/sets the configuration of the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s error handling
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.TransitionToken">
-            <summary>
-            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/>
-            </summary>
-        </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.Transition">
             <summary>
-            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/>
+            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.OneOf`2"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/>
             </summary>
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.StateDefinition.DataInputSchemaToken">
@@ -1485,24 +1455,14 @@
             Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition"/>'s name
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition.TransitionToken">
+        <member name="P:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition.Transition">
             <summary>
             Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/>
             </summary>
         </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition.Transition">
-            <summary>
-            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/> that should be performed when the condition is met
-            </summary>
-        </member>
-        <member name="P:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition.EndToken">
-            <summary>
-            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/>
-            </summary>
-        </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition.End">
             <summary>
-            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/> that should be performed when the condition is met
+            Gets/sets the <see cref="T:Newtonsoft.Json.Linq.JToken"/> that represents the <see cref="T:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/>
             </summary>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Models.SwitchCaseDefinition.ToString">
@@ -1636,6 +1596,11 @@
         <member name="P:ServerlessWorkflow.Sdk.Models.WorkflowDefinition.Start">
             <summary>
             Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s <see cref="T:ServerlessWorkflow.Sdk.Models.StartDefinition"/>
+            </summary>
+        </member>
+        <member name="P:ServerlessWorkflow.Sdk.Models.WorkflowDefinition.StartState">
+            <summary>
+            Gets/sets the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/>'s start <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>. If not set, defaults to the first defined <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/>
             </summary>
         </member>
         <member name="P:ServerlessWorkflow.Sdk.Models.WorkflowDefinition.KeepActive">
@@ -5892,6 +5857,13 @@
             Gets the <see cref="T:ServerlessWorkflow.Sdk.Models.WorkflowDefinition"/> to validate
             </summary>
         </member>
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1.ReferenceExistingState(ServerlessWorkflow.Sdk.Models.OneOf{ServerlessWorkflow.Sdk.Models.TransitionDefinition,System.String})">
+            <summary>
+            Determines whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> exists
+            </summary>
+            <param name="oneOf">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> to check</param>
+            <returns>A boolean indicating whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> exists</returns>
+        </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1.ReferenceExistingState(System.String)">
             <summary>
             Determines whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> exists
@@ -5906,27 +5878,20 @@
             <param name="eventName">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.EventDefinition"/> to check</param>
             <returns>A boolean indicating whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.EventDefinition"/> exists</returns>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1.ReferenceExistingState(ServerlessWorkflow.Sdk.Models.TransitionDefinition)">
-            <summary>
-            Determines whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> exists
-            </summary>
-            <param name="transition">The <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/> that references the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> to check</param>
-            <returns>A boolean indicating whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> exists</returns>
-        </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1.DefineCompensationState(`0,ServerlessWorkflow.Sdk.Models.EndDefinition)">
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1.DefineCompensationState(`0,ServerlessWorkflow.Sdk.Models.OneOf{ServerlessWorkflow.Sdk.Models.TransitionDefinition,System.String})">
             <summary>
             Determines whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> defines a compensation state
             </summary>
             <param name="state">The <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> to check</param>
-            <param name="endDefinition">The <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/> that references the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> to check</param>
+            <param name="oneOf">The <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/> that references the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> to check</param>
             <returns>A boolean indicating whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> defines a compensation state</returns>
         </member>
-        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1.DefineCompensationState(`0,ServerlessWorkflow.Sdk.Models.TransitionDefinition)">
+        <member name="M:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1.DefineCompensationState(`0,ServerlessWorkflow.Sdk.Models.OneOf{ServerlessWorkflow.Sdk.Models.EndDefinition,System.Boolean})">
             <summary>
             Determines whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> defines a compensation state
             </summary>
             <param name="state">The <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> to check</param>
-            <param name="transitionDefinition">The <see cref="T:ServerlessWorkflow.Sdk.Models.TransitionDefinition"/> that references the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> to check</param>
+            <param name="oneOf">The <see cref="T:ServerlessWorkflow.Sdk.Models.EndDefinition"/> that references the <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> to check</param>
             <returns>A boolean indicating whether or not the specified <see cref="T:ServerlessWorkflow.Sdk.Models.StateDefinition"/> defines a compensation state</returns>
         </member>
         <member name="M:ServerlessWorkflow.Sdk.Services.Validation.StateDefinitionValidator`1.BeAvailableForCompensation(`0,System.Boolean)">

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.xml
@@ -492,6 +492,21 @@
             Gets/sets the duration to wait for incoming events
             </summary>
         </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.EventStateDefinition.GetTrigger(System.Int32)">
+            <summary>
+            Gets the <see cref="T:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition"/> with the specified id
+            </summary>
+            <param name="id">The id of the <see cref="T:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition"/> to get</param>
+            <returns>The <see cref="T:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition"/> with the specified id</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.EventStateDefinition.TryGetTrigger(System.Int32,ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition@)">
+            <summary>
+            Attempts to get the <see cref="T:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition"/> with the specified id
+            </summary>
+            <param name="id">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition"/> to get</param>
+            <param name="trigger">The <see cref="T:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition"/> with the specified id</param>
+            <returns>A boolean indicating whether or not a <see cref="T:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition"/> with the specified id could be found</returns>
+        </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition">
             <summary>
             Represents the definition of an <see cref="T:ServerlessWorkflow.Sdk.Models.EventStateDefinition"/>'s trigger
@@ -516,6 +531,29 @@
             <summary>
             Gets/sets an object used to filter the event data 
             </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition.GetAction(System.String)">
+            <summary>
+            Gets the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get</param>
+            <returns>The <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition.TryGetAction(System.String,ServerlessWorkflow.Sdk.Models.ActionDefinition@)">
+            <summary>
+            Attempts to get the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get</param>
+            <param name="action">The <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name</param>
+            <returns>A boolean indicating whether or not a <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name could be found</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.EventStateTriggerDefinition.TryGetNextAction(System.String,ServerlessWorkflow.Sdk.Models.ActionDefinition@)">
+            <summary>
+            Attempts to get the next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> in the pipeline
+            </summary>
+            <param name="previousActionName">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get the next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> for</param>
+            <param name="action">The next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/>, if any</param>
+            <returns>A boolean indicating whether or not there is a next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> in the pipeline</returns>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.ExecutionTimeoutDefinition">
             <summary>
@@ -692,6 +730,29 @@
             <summary>
             Gets/sets the unique Id of a workflow to be executed for each of the elements of <see cref="P:ServerlessWorkflow.Sdk.Models.ForEachStateDefinition.InputCollection"/>
             </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.ForEachStateDefinition.GetAction(System.String)">
+            <summary>
+            Gets the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get</param>
+            <returns>The <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.ForEachStateDefinition.TryGetAction(System.String,ServerlessWorkflow.Sdk.Models.ActionDefinition@)">
+            <summary>
+            Attempts to get the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get</param>
+            <param name="action">The <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name</param>
+            <returns>A boolean indicating whether or not a <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name could be found</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.ForEachStateDefinition.TryGetNextAction(System.String,ServerlessWorkflow.Sdk.Models.ActionDefinition@)">
+            <summary>
+            Attempts to get the next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> in the pipeline
+            </summary>
+            <param name="previousActionName">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get the next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> for</param>
+            <param name="action">The next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/>, if any</param>
+            <returns>A boolean indicating whether or not there is a next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> in the pipeline</returns>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.FunctionDefinition">
             <summary>
@@ -925,6 +986,29 @@
             Gets/sets an <see cref="T:System.Collections.Generic.List`1"/> of actions to be performed if expression matches
             </summary>
         </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OperationStateDefinition.GetAction(System.String)">
+            <summary>
+            Gets the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get</param>
+            <returns>The <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OperationStateDefinition.TryGetAction(System.String,ServerlessWorkflow.Sdk.Models.ActionDefinition@)">
+            <summary>
+            Attempts to get the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get</param>
+            <param name="action">The <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name</param>
+            <returns>A boolean indicating whether or not a <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> with the specified name could be found</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.OperationStateDefinition.TryGetNextAction(System.String,ServerlessWorkflow.Sdk.Models.ActionDefinition@)">
+            <summary>
+            Attempts to get the next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> in the pipeline
+            </summary>
+            <param name="previousActionName">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> to get the next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> for</param>
+            <param name="action">The next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/>, if any</param>
+            <returns>A boolean indicating whether or not there is a next <see cref="T:ServerlessWorkflow.Sdk.Models.ActionDefinition"/> in the pipeline</returns>
+        </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.ParallelStateDefinition">
             <summary>
             Represents a workflow state that executes <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/>es in parallel
@@ -949,6 +1033,21 @@
             <summary>
             Gets/sets a value that represents the amount of <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/>es to complete for completing the state, when <see cref="P:ServerlessWorkflow.Sdk.Models.ParallelStateDefinition.CompletionType"/> is set to <see cref="F:ServerlessWorkflow.Sdk.ParallelCompletionType.N"/>
             </summary>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.ParallelStateDefinition.GetBranch(System.String)">
+            <summary>
+            Gets the <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/> to get</param>
+            <returns>The <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/> with the specified name</returns>
+        </member>
+        <member name="M:ServerlessWorkflow.Sdk.Models.ParallelStateDefinition.TryGetBranch(System.String,ServerlessWorkflow.Sdk.Models.BranchDefinition@)">
+            <summary>
+            Attempts to get the <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/> with the specified name
+            </summary>
+            <param name="name">The name of the <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/> to get</param>
+            <param name="branch">The <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/> with the specified name</param>
+            <returns>A boolean indicating whether or not a <see cref="T:ServerlessWorkflow.Sdk.Models.BranchDefinition"/> with the specified name could be found</returns>
         </member>
         <member name="T:ServerlessWorkflow.Sdk.Models.ProduceEventDefinition">
             <summary>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflowSpecVersion.cs
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflowSpecVersion.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace ServerlessWorkflow.Sdk
+{
+
+    /// <summary>
+    /// Exposes all supported Serverless Workflow spec versions
+    /// </summary>
+    public static class ServerlessWorkflowSpecVersion
+    {
+
+        /// <summary>
+        /// Gets the latest supported spec version
+        /// </summary>
+        public const string Latest = V0_7;
+
+        /// <summary>
+        /// Gets the v0.6.x version
+        /// </summary>
+        public const string V0_6 = "0.6.x";
+
+        /// <summary>
+        /// Gets the v0.7.x version
+        /// </summary>
+        public const string V0_7 = "0.7.x";
+
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/ActionBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/ActionBuilder.cs
@@ -14,10 +14,10 @@
  * limitations under the License.
  *
  */
-using Newtonsoft.Json.Linq;
 using ServerlessWorkflow.Sdk.Models;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
 {
@@ -110,14 +110,16 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         /// <inheritdoc/>
         public virtual IFunctionActionBuilder WithArgument(string name, string value)
         {
-            this.Action.Function.Arguments.Add(name, value);
+            if (this.Action.Function.Arguments == null)
+                this.Action.Function.Arguments = new();
+            this.Action.Function.Arguments.Set(name, value);
             return this;
         }
 
         /// <inheritdoc/>
         public virtual IFunctionActionBuilder WithArguments(IDictionary<string, string> args)
         {
-            this.Action.Function.Arguments = JObject.FromObject(args);
+            this.Action.Function.Arguments = new(args.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value));
             return this;
         }
 
@@ -167,16 +169,24 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         }
 
         /// <inheritdoc/>
+        public virtual IEventTriggerActionBuilder ThenProduce(Action<IEventBuilder> eventSetup)
+        {
+            EventDefinition e = this.Pipeline.AddEvent(eventSetup);
+            this.Action.Event.ResultEvent = e.Name;
+            return this;
+        }
+
+        /// <inheritdoc/>
         public virtual IEventTriggerActionBuilder WithContextAttribute(string name, string value)
         {
-            this.Action.Event.ContextAttributes.Add(name, value);
+            this.Action.Event.ContextAttributes.Set(name, value);
             return this;
         }
 
         /// <inheritdoc/>
         public virtual IEventTriggerActionBuilder WithContextAttribute(IDictionary<string, string> contextAttributes)
         {
-            this.Action.Event.ContextAttributes = JObject.FromObject(contextAttributes);
+            this.Action.Event.ContextAttributes = new(contextAttributes.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value));
             return this;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/DelayStateBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/DelayStateBuilder.cs
@@ -23,7 +23,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
     /// Represents the default implementation of the <see cref="IDelayStateBuilder"/> interface
     /// </summary>
     public class DelayStateBuilder
-        : StateBuilder<DelayStateDefinition>, IDelayStateBuilder
+        : StateBuilder<SleepStateDefinition>, IDelayStateBuilder
     {
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/EventBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/EventBuilder.cs
@@ -35,7 +35,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         protected EventDefinition Event { get; } = new EventDefinition();
 
         /// <inheritdoc/>
-        public override JObject Metadata
+        public override Any Metadata
         {
             get
             {

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/FunctionBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/FunctionBuilder.cs
@@ -47,7 +47,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         protected FunctionDefinition Function { get; } = new FunctionDefinition();
 
         /// <inheritdoc/>
-        public override JObject Metadata
+        public override Any Metadata
         {
             get
             {

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/InjectStateBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/InjectStateBuilder.cs
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-using Newtonsoft.Json.Linq;
+using Neuroglia;
 using ServerlessWorkflow.Sdk.Models;
 using System;
 
@@ -42,7 +42,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         {
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
-            this.State.Data = JObject.FromObject(data);
+            this.State.Data = data is Any any ? any : new(data.ToDictionary());
             return this;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/Interfaces/IDelayStateBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/Interfaces/IDelayStateBuilder.cs
@@ -20,10 +20,10 @@ using System;
 namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
 {
     /// <summary>
-    /// Defines the fundamentals of a service used to build <see cref="DelayStateDefinition"/>s
+    /// Defines the fundamentals of a service used to build <see cref="SleepStateDefinition"/>s
     /// </summary>
     public interface IDelayStateBuilder
-        : IStateBuilder<DelayStateDefinition>
+        : IStateBuilder<SleepStateDefinition>
     {
 
         /// <summary>

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/Interfaces/IEventTriggerActionBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/Interfaces/IEventTriggerActionBuilder.cs
@@ -16,6 +16,7 @@
  */
 using CloudNative.CloudEvents;
 using ServerlessWorkflow.Sdk.Models;
+using System;
 using System.Collections.Generic;
 
 namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
@@ -32,6 +33,13 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         /// <param name="e">The reference name of the <see cref="EventDefinition"/> to produce. Requires the referenced <see cref="EventDefinition"/> to have been previously defined.</param>
         /// <returns>The configured <see cref="IEventTriggerActionBuilder"/></returns>
         IEventTriggerActionBuilder ThenProduce(string e);
+
+        /// <summary>
+        /// Configures the <see cref="ActionDefinition"/> to produce the specified <see cref="EventDefinition"/> when triggered
+        /// </summary>
+        /// <param name="eventSetup">The <see cref="Action{T}"/> used to create the <see cref="EventDefinition"/> to produce</param>
+        /// <returns>The configured <see cref="IActionBuilder"/></returns>
+        IEventTriggerActionBuilder ThenProduce(Action<IEventBuilder> eventSetup);
 
         /// <summary>
         /// Adds the specified context attribute to the <see cref="CloudEvent"/> produced as a result of the trigger

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/Interfaces/IMetadataContainerBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/Interfaces/IMetadataContainerBuilder.cs
@@ -15,6 +15,7 @@
  *
  */
 using Newtonsoft.Json.Linq;
+using ServerlessWorkflow.Sdk.Models;
 using System.Collections.Generic;
 
 namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
@@ -30,7 +31,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         /// <summary>
         /// Gets the container's metadata
         /// </summary>
-        JObject Metadata { get; }
+        Any Metadata { get; }
 
         /// <summary>
         /// Adds the specified metadata

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/Interfaces/IStateBuilderFactory.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/Interfaces/IStateBuilderFactory.cs
@@ -34,14 +34,14 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         ICallbackStateBuilder Callback();
 
         /// <summary>
-        /// Creates and configures a new <see cref="DelayStateDefinition"/>
+        /// Creates and configures a new <see cref="SleepStateDefinition"/>
         /// </summary>
         /// <param name="duration">The delay's duration</param>
         /// <returns>A new <see cref="IDelayStateBuilder"/></returns>
         IDelayStateBuilder Delay(TimeSpan duration);
 
         /// <summary>
-        /// Creates and configures a new <see cref="DelayStateDefinition"/>
+        /// Creates and configures a new <see cref="SleepStateDefinition"/>
         /// </summary>
         /// <returns>A new <see cref="IDelayStateBuilder"/></returns>
         IDelayStateBuilder Delay();

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/MetadataContainerBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/MetadataContainerBuilder.cs
@@ -15,6 +15,7 @@
  *
  */
 using Newtonsoft.Json.Linq;
+using ServerlessWorkflow.Sdk.Models;
 using System;
 using System.Collections.Generic;
 
@@ -31,17 +32,14 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
     {
 
         /// <inheritdoc/>
-        public abstract JObject Metadata { get; }
+        public abstract Any Metadata { get; }
 
         /// <inheritdoc/>
         public virtual TContainer WithMetadata(string key, object value)
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
-            JToken token = null;
-            if (value != null)
-                token = JToken.FromObject(value);
-            this.Metadata.Add(key, token);
+            this.Metadata.Set(key, value);
             return (TContainer)(object)this;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/PipelineBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/PipelineBuilder.cs
@@ -117,7 +117,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
             if (stateSetup == null)
                 throw new ArgumentNullException(nameof(stateSetup));
             var nextState = this.AddState(stateSetup);
-            this.CurrentState.Transition = new() { To = nextState.Name };
+            this.CurrentState.Transition = nextState.Name;
             this.CurrentState = nextState;
             return this;
         }
@@ -151,7 +151,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         /// <inheritdoc/>
         public virtual IWorkflowBuilder End()
         {
-            this.CurrentState.End = new EndDefinition() {  };
+            this.CurrentState.End = true;
             return this.Workflow;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/PipelineBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/PipelineBuilder.cs
@@ -116,7 +116,9 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         {
             if (stateSetup == null)
                 throw new ArgumentNullException(nameof(stateSetup));
-            this.CurrentState = this.AddState(stateSetup);
+            var nextState = this.AddState(stateSetup);
+            this.CurrentState.Transition = new() { To = nextState.Name };
+            this.CurrentState = nextState;
             return this;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/StateBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/StateBuilder.cs
@@ -101,7 +101,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
             if (stateSetup == null)
                 throw new ArgumentNullException(nameof(stateSetup));
             StateDefinition compensatedBy = this.Pipeline.AddState(stateSetup);
-            compensatedBy.UseForCompensation = true;
+            compensatedBy.UsedForCompensation = true;
             this.State.CompensatedBy = compensatedBy.Name;
             return this;
         }
@@ -111,7 +111,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         {
             if (state == null)
                 throw new ArgumentNullException(nameof(state));
-            state.UseForCompensation = true;
+            state.UsedForCompensation = true;
             this.State.CompensatedBy = this.Pipeline.AddState(state).Name;
             return this;
         }

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/StateBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/StateBuilder.cs
@@ -50,7 +50,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         protected TState State { get; } = new TState();
 
         /// <inheritdoc/>
-        public override JObject Metadata
+        public override Any Metadata
         {
             get
             {

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/WorkflowBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/WorkflowBuilder.cs
@@ -249,6 +249,8 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         {
             if (e == null)
                 throw new ArgumentNullException(nameof(e));
+            if (this.Workflow.Events == null)
+                this.Workflow.Events = new();
             if (this.Workflow.Events.Any(ed => ed.Name == e.Name))
                 throw new ArgumentException($"The workflow already defines an event with the specified name '{e.Name}'", nameof(e));
             this.Workflow.Events.Add(e);
@@ -277,6 +279,8 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         {
             if (function == null)
                 throw new ArgumentNullException(nameof(function));
+            if(this.Workflow.Functions == null)
+                this.Workflow.Functions = new();
             if (this.Workflow.Functions.Any(fd => fd.Name == function.Name))
                 throw new ArgumentException($"The workflow already defines a function with the specified name '{function.Name}'", nameof(function));
             this.Workflow.Functions.Add(function);
@@ -305,6 +309,8 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         {
             if (strategy == null)
                 throw new ArgumentNullException(nameof(strategy));
+            if(this.Workflow.Retries == null)
+                this.Workflow.Retries = new();
             if (this.Workflow.Retries.Any(rs => rs.Name == strategy.Name))
                 throw new ArgumentException($"The workflow already defines a function with the specified name '{strategy.Name}'", nameof(strategy));
             this.Workflow.Retries.Add(strategy);

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/WorkflowBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/WorkflowBuilder.cs
@@ -387,7 +387,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
             if (state == null)
                 throw new ArgumentNullException(nameof(state));
             this.Pipeline.AddState(state);
-            this.Workflow.Start = new StartDefinition() { StateName = state.Name };
+            this.Workflow.StartState = state.Name;
             return this.Pipeline;
         }
 
@@ -397,7 +397,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
             if (stateSetup == null)
                 throw new ArgumentNullException(nameof(stateSetup));
             StateDefinition state = this.Pipeline.AddState(stateSetup);
-            this.Workflow.Start = new StartDefinition() { StateName = state.Name };
+            this.Workflow.StartState = state.Name;
             return this.Pipeline;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/WorkflowBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/WorkflowBuilder.cs
@@ -387,7 +387,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
             if (state == null)
                 throw new ArgumentNullException(nameof(state));
             this.Pipeline.AddState(state);
-            this.Workflow.StartState = state.Name;
+            this.Workflow.Start = state.Name;
             return this.Pipeline;
         }
 
@@ -397,7 +397,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
             if (stateSetup == null)
                 throw new ArgumentNullException(nameof(stateSetup));
             StateDefinition state = this.Pipeline.AddState(stateSetup);
-            this.Workflow.StartState = state.Name;
+            this.Workflow.Start = state.Name;
             return this.Pipeline;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/WorkflowBuilder.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/FluentBuilders/WorkflowBuilder.cs
@@ -78,7 +78,7 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
         protected IPipelineBuilder Pipeline { get; }
 
         /// <inheritdoc/>
-        public override JObject Metadata
+        public override Any Metadata
         {
             get
             {
@@ -216,8 +216,8 @@ namespace ServerlessWorkflow.Sdk.Services.FluentBuilders
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
             if (this.Workflow.Constants == null)
-                this.Workflow.Constants = new JObject();
-            this.Workflow.Constants.Add(name, JToken.FromObject(value));
+                this.Workflow.Constants = new();
+            //this.Workflow.Constants.Set(name, value); //todo: URGENT
             return this;
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/IO/Interfaces/IWorkflowSchemaValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/IO/Interfaces/IWorkflowSchemaValidator.cs
@@ -14,11 +14,15 @@
  * limitations under the License.
  *
  */
+using Newtonsoft.Json.Schema;
 using ServerlessWorkflow.Sdk.Models;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ServerlessWorkflow.Sdk.Services.IO
 {
+
     /// <summary>
     /// Defines the fundamentals of a service used to validate <see cref="WorkflowDefinition"/>s
     /// </summary>
@@ -26,12 +30,21 @@ namespace ServerlessWorkflow.Sdk.Services.IO
     {
 
         /// <summary>
+        /// Validates the specified <see cref="WorkflowDefinition"/>
+        /// </summary>
+        /// <param name="workflow">The input to validate</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+        /// <returns>An <see cref="IList{T}"/> containing the <see cref="ValidationError"/>s that have occured</returns>
+        Task<IList<ValidationError>> ValidateAsync(WorkflowDefinition workflow, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Validates the specified JSON input
         /// </summary>
         /// <param name="json">The input to validate</param>
-        /// <param name="errors">An <see cref="IList{T}"/> containing the validation errors key/value pairs</param>
-        /// <returns>A boolean indicating whether or not the specified JSON input is a valid <see cref="WorkflowDefinition"/></returns>
-        bool Validate(string json, out IList<string> errors);
+        /// <param name="specVersion">The Serverless Workflow spec version to evaluate the <see cref="WorkflowDefinition"/> against</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+        /// <returns>An <see cref="IList{T}"/> containing the <see cref="ValidationError"/>s that have occured</returns>
+        Task<IList<ValidationError>> ValidateAsync(string json, string specVersion, CancellationToken cancellationToken = default);
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/Services/IO/WorkflowSchemaValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/IO/WorkflowSchemaValidator.cs
@@ -76,6 +76,10 @@ namespace ServerlessWorkflow.Sdk.Services.IO
             if (workflow == null)
                 throw new ArgumentNullException(nameof(workflow));
             var obj = JObject.FromObject(workflow);
+
+            //todo: remove
+            var json = obj.ToString();
+
             var schema = await this.LoadSchemaAsync(workflow.SpecVersion);
             obj.IsValid(schema, out IList<ValidationError> validationErrors);
             return validationErrors;

--- a/src/ServerlessWorkflow.Sdk/Services/Validation/ErrorHandlerDefinitionValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/Validation/ErrorHandlerDefinitionValidator.cs
@@ -44,7 +44,7 @@ namespace ServerlessWorkflow.Sdk.Services.Validation
             this.RuleFor(h => h.End)
                 .NotNull()
                 .When(h => h.Transition == null);
-            this.RuleFor(h => h.Transition.Value1)
+            this.RuleFor(h => h.Transition.T1Value)
                 .NotNull()
                 .When(h => h.End == null)
                 .SetValidator(new TransitionDefinitionValidator(workflow));

--- a/src/ServerlessWorkflow.Sdk/Services/Validation/ErrorHandlerDefinitionValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/Validation/ErrorHandlerDefinitionValidator.cs
@@ -44,9 +44,9 @@ namespace ServerlessWorkflow.Sdk.Services.Validation
             this.RuleFor(h => h.End)
                 .NotNull()
                 .When(h => h.Transition == null);
-            this.RuleFor(h => h.Transition)
+            this.RuleFor(h => h.Transition.Value1)
                 .NotNull()
-                    .When(h => h.End == null)
+                .When(h => h.End == null)
                 .SetValidator(new TransitionDefinitionValidator(workflow));
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/Validation/SleepStateValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/Validation/SleepStateValidator.cs
@@ -20,17 +20,17 @@ namespace ServerlessWorkflow.Sdk.Services.Validation
 {
 
     /// <summary>
-    /// Represents a service used to validate <see cref="DelayStateDefinition"/>s
+    /// Represents a service used to validate <see cref="SleepStateDefinition"/>s
     /// </summary>
-    public class DelayStateValidator
-        : StateDefinitionValidator<DelayStateDefinition>
+    public class SleepStateValidator
+        : StateDefinitionValidator<SleepStateDefinition>
     {
 
         /// <summary>
-        /// Initializes a new <see cref="DelayStateValidator"/>
+        /// Initializes a new <see cref="SleepStateValidator"/>
         /// </summary>
         /// <param name="workflow">The <see cref="WorkflowDefinition"/> to validate</param>
-        public DelayStateValidator(WorkflowDefinition workflow)
+        public SleepStateValidator(WorkflowDefinition workflow)
             : base(workflow)
         {
             

--- a/src/ServerlessWorkflow.Sdk/Services/Validation/StateDefinitionValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/Validation/StateDefinitionValidator.cs
@@ -47,11 +47,11 @@ namespace ServerlessWorkflow.Sdk.Services.Validation
                 .When(s => s.Transition != null)
                 .WithMessage((state, stateName) => $"Failed to find the state '{stateName}' to transition to")
                 .Must(DefineCompensationState)
-                .When(s => s.Transition?.Value1 != null && s.Transition.Value1.Compensate)
+                .When(s => s.Transition?.T1Value != null && s.Transition.T1Value.Compensate)
                 .WithMessage(state => $"The '{nameof(StateDefinition.CompensatedBy)}' property of the state '{state.Name}' must be set when enabling its compensation (in both Transition and End definitions)");
             this.RuleFor(s => s.End)
                 .Must(DefineCompensationState)
-                .When(s => s.End?.Value1 != null && s.End.Value1.Compensate)
+                .When(s => s.End?.T1Value != null && s.End.T1Value.Compensate)
                 .WithMessage(state => $"The '{nameof(StateDefinition.CompensatedBy)}' property of the state '{state.Name}' must be set when enabling its compensation (in both Transition and End definitions)");
             this.RuleForEach(s => s.Errors)
                 .SetValidator((s, e) => new ErrorHandlerDefinitionValidator(this.Workflow, s));
@@ -74,10 +74,10 @@ namespace ServerlessWorkflow.Sdk.Services.Validation
         protected virtual bool ReferenceExistingState(OneOf<TransitionDefinition, string> oneOf)
         {
             string stateName = null;
-            if (oneOf.Value1 == null)
-                stateName = oneOf.Value2;
+            if (oneOf.T1Value == null)
+                stateName = oneOf.T2Value;
             else
-                stateName = oneOf.Value1.To;
+                stateName = oneOf.T1Value.To;
             return this.Workflow.TryGetState(stateName, out _);
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/Validation/StateDefinitionValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/Validation/StateDefinitionValidator.cs
@@ -55,9 +55,9 @@ namespace ServerlessWorkflow.Sdk.Services.Validation
                 .WithMessage(state => $"The '{nameof(StateDefinition.CompensatedBy)}' property of the state '{state.Name}' must be set when enabling its compensation (in both Transition and End definitions)");
             this.RuleForEach(s => s.Errors)
                 .SetValidator((s, e) => new ErrorHandlerDefinitionValidator(this.Workflow, s));
-            this.RuleFor(s => s.UseForCompensation)
+            this.RuleFor(s => s.UsedForCompensation)
                 .Must(BeAvailableForCompensation)
-                .When(state => state.UseForCompensation)
+                .When(state => state.UsedForCompensation)
                 .WithMessage(state => $"The state with name '{state.Name}' must not be part of the main control flow to be used as a compensation state");
         }
 

--- a/src/ServerlessWorkflow.Sdk/Services/Validation/WorkflowStatesPropertyValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Services/Validation/WorkflowStatesPropertyValidator.cs
@@ -47,7 +47,8 @@ namespace ServerlessWorkflow.Sdk.Services.Validation
             this.ServiceProvider = serviceProvider;
         }
 
-        public override string Name => throw new NotImplementedException();
+        /// <inheritdoc/>
+        public override string Name => typeof(WorkflowStatesPropertyValidator).Name;
 
         /// <summary>
         /// Gets the current <see cref="IServiceProvider"/>

--- a/src/ServerlessWorkflow.Sdk/StateType.cs
+++ b/src/ServerlessWorkflow.Sdk/StateType.cs
@@ -33,10 +33,10 @@ namespace ServerlessWorkflow.Sdk
         [EnumMember(Value = "operation")]
         Operation,
         /// <summary>
-        /// Indicates a delay state
+        /// Indicates a sleep state
         /// </summary>
-        [EnumMember(Value = "delay")]
-        Delay,
+        [EnumMember(Value = "sleep")]
+        Sleep,
         /// <summary>
         /// Indicates an event state
         /// </summary>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Updates solution to NET 6.0
- Replaced Newtonsoft JSON specific type usage (Jtoken, JObjects, ...) by (partially) serializer agnostic ones (Any, OneOf<T1,T2>)
- Added support for ProtoBuf serialization
- Added support for DataContact based serialization
- Added both schema-based spec validation support and fluent spec validation to the WorkflowReader's validation logic

**Special notes for reviewers**:

A YAML related issue has been introduced, making the reader throw an exception when dealing with AnyOf<T1, T2> instances, when a T2 value is used. The issue is related to https://github.com/aaubry/YamlDotNet/issues/675