### PR TITLE
Correct DataMember name for `SwitchStatementDefinition.DefaultCondition`.

### DIFF
--- a/src/ServerlessWorkflow.Sdk/Models/States/SwitchStateDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/States/SwitchStateDefinition.cs
@@ -65,7 +65,7 @@ public class SwitchStateDefinition
     /// Gets/sets an object used to configure the <see cref="SwitchStateDefinition"/>'s default condition, in case none of the specified conditions were met
     /// </summary>
     [Required, MinLength(1)]
-    [DataMember(Order = 9, Name = "name", IsRequired = true), JsonPropertyOrder(9), JsonPropertyName("name"), YamlMember(Alias = "name", Order = 9)]
+    [DataMember(Order = 9, Name = "defaultCondition", IsRequired = true), JsonPropertyOrder(9), JsonPropertyName("defaultCondition"), YamlMember(Alias = "defaultCondition", Order = 9)]
     public virtual DefaultCaseDefinition DefaultCondition { get; set; } = null!;
 
     /// <summary>


### PR DESCRIPTION
Fixes #48.
Signed-off-by: Elan Hasson <234704+ElanHasson@users.noreply.github.com>
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Corrects the data member name to enable the switch state to be parsed.

**Special notes for reviewers**:

**Additional information (if needed):**