### PR TITLE
 A member with the name 'eventRef' already exists

### DIFF
--- a/src/ServerlessWorkflow.Sdk/Models/ActionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ActionDefinition.cs
@@ -85,7 +85,7 @@ public class ActionDefinition
     /// <summary>
     /// Gets/sets a <see cref="OneOf{T1, T2}"/> that references a subflow to run
     /// </summary>
-    [DataMember(Order = 4, Name = "eventRef"), JsonPropertyOrder(4), JsonPropertyName("eventRef"), YamlMember(Alias = "eventRef", Order = 4)]
+    [DataMember(Order = 4, Name = "subFlowRef"), JsonPropertyOrder(4), JsonPropertyName("subFlowRef"), YamlMember(Alias = "subFlowRef", Order = 4)]
     [JsonConverter(typeof(OneOfConverter<SubflowReference, string>))]
     protected virtual OneOf<SubflowReference, string>? SubflowValue { get; set; }
 


### PR DESCRIPTION
 A member with the name 'eventRef' already exists on 'ServerlessWorkflow.Sdk.Models.ActionDefinition'
Signed-off-by: Flex Xuan <flex.xuan@outlook.com>
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

**Special notes for reviewers**:

**Additional information (if needed):**