### PR TITLE
Fixed the `CallTaskDefinitionValidator` to not check the inline definition of cataloged functions (which contain an '@' character)

### DIFF
--- a/src/ServerlessWorkflow.Sdk.Builders/ServerlessWorkflow.Sdk.Builders.csproj
+++ b/src/ServerlessWorkflow.Sdk.Builders/ServerlessWorkflow.Sdk.Builders.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3</VersionSuffix>
+	<VersionSuffix>alpha3.1</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>

--- a/src/ServerlessWorkflow.Sdk.IO/ServerlessWorkflow.Sdk.IO.csproj
+++ b/src/ServerlessWorkflow.Sdk.IO/ServerlessWorkflow.Sdk.IO.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3</VersionSuffix>
+	<VersionSuffix>alpha3.1</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3</VersionSuffix>
+	<VersionSuffix>alpha3.1</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>

--- a/src/ServerlessWorkflow.Sdk/Validation/CallTaskDefinitionValidator.cs
+++ b/src/ServerlessWorkflow.Sdk/Validation/CallTaskDefinitionValidator.cs
@@ -35,7 +35,7 @@ public class CallTaskDefinitionValidator
         this.Components = components;
         this.RuleFor(c => c.Call)
             .Must(ReferenceAnExistingFunction)
-            .When(c => !Uri.TryCreate(c.Call, UriKind.Absolute, out _))
+            .When(c => !Uri.TryCreate(c.Call, UriKind.Absolute, out _) || c.Call.Contains('@'))
             .WithMessage(ValidationErrors.UndefinedFunction);
         this.When(c => c.Call == Function.AsyncApi, () =>
         {


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes the `CallTaskDefinitionValidator` to not check the inline definition of cataloged functions (which contain an '@' character)