### PR TITLE
Update OAuth2AuthenticationEndpointsDefinition to correct the member name of property Token

### DIFF
--- a/src/ServerlessWorkflow.Sdk/Models/Authentication/OAuth2AuthenticationEndpointsDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Authentication/OAuth2AuthenticationEndpointsDefinition.cs
@@ -24,7 +24,7 @@ public record OAuth2AuthenticationEndpointsDefinition
     /// Gets/sets the relative path to the token endpoint. Defaults to `/oauth2/token`
     /// </summary>
     [Required]
-    [DataMember(Name = "authority", Order = 1), JsonPropertyName("authority"), JsonPropertyOrder(1), YamlMember(Alias = "authority", Order = 1)]
+    [DataMember(Name = "token", Order = 1), JsonPropertyName("token"), JsonPropertyOrder(1), YamlMember(Alias = "token", Order = 1)]
     public virtual Uri Token { get; set; } = new("/oauth2/token", UriKind.RelativeOrAbsolute);
 
     /// <summary>


### PR DESCRIPTION
fix the member name when serialize/deseialize the definition
Signed-off-by: Flex Xuan [flex.xuan@outlook.com](mailto:flex.xuan@outlook.com)

**What this PR does / why we need it**: The data member name is not correct for token 

**Special notes for reviewers**: No
