### PR TITLE
Implement ServerlessWorkflow `v1.0.0-alpha6`

### DIFF
--- a/src/ServerlessWorkflow.Sdk.Builders/ServerlessWorkflow.Sdk.Builders.csproj
+++ b/src/ServerlessWorkflow.Sdk.Builders/ServerlessWorkflow.Sdk.Builders.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.4</VersionSuffix>
+	<VersionSuffix>alpha6</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>

--- a/src/ServerlessWorkflow.Sdk.IO/ServerlessWorkflow.Sdk.IO.csproj
+++ b/src/ServerlessWorkflow.Sdk.IO/ServerlessWorkflow.Sdk.IO.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.4</VersionSuffix>
+	<VersionSuffix>alpha6</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>

--- a/src/ServerlessWorkflow.Sdk/ContainerCleanupPolicy.cs
+++ b/src/ServerlessWorkflow.Sdk/ContainerCleanupPolicy.cs
@@ -1,0 +1,46 @@
+﻿// Copyright © 2024-Present The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ServerlessWorkflow.Sdk;
+
+/// <summary>
+/// Enumerates all supported container cleanup policies
+/// </summary>
+public static class ContainerCleanupPolicy
+{
+
+    /// <summary>
+    /// Indicates that the runtime must delete the container immediately after execution
+    /// </summary>
+    public const string Always = "always";
+    /// <summary>
+    /// Indicates that the runtime must eventually delete the container, after waiting for a specific amount of time.
+    /// </summary>
+    public const string Eventually = "eventually";
+    /// <summary>
+    /// Indicates that the runtime must never delete the container.
+    /// </summary>
+    public const string Never = "never";
+
+    /// <summary>
+    /// Gets a new <see cref="IEnumerable{T}"/> containing all supported values
+    /// </summary>
+    /// <returns>A new <see cref="IEnumerable{T}"/> containing all supported values</returns>
+    public static IEnumerable<string> AsEnumerable()
+    {
+        yield return Always;
+        yield return Eventually;
+        yield return Never;
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Models/AsyncApiMessageDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/AsyncApiMessageDefinition.cs
@@ -1,0 +1,35 @@
+﻿// Copyright © 2024-Present The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ServerlessWorkflow.Sdk.Models;
+
+/// <summary>
+/// Represents the definition of an AsyncAPI message
+/// </summary>
+[DataContract]
+public record AsyncApiMessageDefinition
+{
+
+    /// <summary>
+    /// Gets/sets the message's payload, if any
+    /// </summary>
+    [DataMember(Name = "payload", Order = 1), JsonPropertyName("payload"), JsonPropertyOrder(1), YamlMember(Alias = "payload", Order = 1)]
+    public virtual object? Payload { get; set; }
+
+    /// <summary>
+    /// Gets/sets the message's headers, if any
+    /// </summary>
+    [DataMember(Name = "headers", Order = 2), JsonPropertyName("headers"), JsonPropertyOrder(2), YamlMember(Alias = "headers", Order = 2)]
+    public virtual object? Headers { get; set; }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Models/AsyncApiSubscriptionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/AsyncApiSubscriptionDefinition.cs
@@ -1,0 +1,36 @@
+﻿// Copyright © 2024-Present The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ServerlessWorkflow.Sdk.Models;
+
+/// <summary>
+/// Represents an object used to configure an AsyncAPI subscription
+/// </summary>
+[DataContract]
+public record AsyncApiSubscriptionDefinition
+{
+
+    /// <summary>
+    /// Gets/sets a runtime expression, if any, used to filter consumed messages
+    /// </summary>
+    [DataMember(Name = "filter", Order = 1), JsonPropertyName("filter"), JsonPropertyOrder(1), YamlMember(Alias = "filter", Order = 1)]
+    public virtual string? Filter { get; set; }
+
+    /// <summary>
+    /// Gets/sets an object used to configure the subscription's lifetime.
+    /// </summary>
+    [Required]
+    [DataMember(Name = "consume", Order = 2), JsonPropertyName("consume"), JsonPropertyOrder(2), YamlMember(Alias = "consume", Order = 2)]
+    public required virtual AsyncApiSubscriptionLifetimeDefinition Consume { get; set; }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Models/AsyncApiSubscriptionLifetimeDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/AsyncApiSubscriptionLifetimeDefinition.cs
@@ -1,0 +1,50 @@
+﻿// Copyright © 2024-Present The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ServerlessWorkflow.Sdk.Models;
+
+/// <summary>
+/// Represents an object used to configure the lifetime of an AsyncAPI subscription
+/// </summary>
+[DataContract]
+public record AsyncApiSubscriptionLifetimeDefinition
+{
+
+    /// <summary>
+    /// Gets/sets the duration that defines for how long to consume messages
+    /// /// </summary>
+    [DataMember(Name = "for", Order = 1), JsonPropertyName("for"), JsonPropertyOrder(1), YamlMember(Alias = "for", Order = 1)]
+    public virtual Duration? For { get; set; }
+
+    /// <summary>
+    /// Gets/sets the amount of messages to consume.<para></para>
+    /// Required if <see cref="While"/> and <see cref="Until"/> have not been set.
+    /// /// </summary>
+    [DataMember(Name = "amount", Order = 2), JsonPropertyName("amount"), JsonPropertyOrder(2), YamlMember(Alias = "amount", Order = 2)]
+    public virtual int? Amount { get; set; }
+
+    /// <summary>
+    /// Gets/sets a runtime expression, if any, used to determine whether or not to keep consuming messages.<para></para>
+    /// Required if <see cref="Amount"/> and <see cref="Until"/> have not been set.
+    /// /// </summary>
+    [DataMember(Name = "while", Order = 3), JsonPropertyName("while"), JsonPropertyOrder(3), YamlMember(Alias = "while", Order = 3)]
+    public virtual int? While { get; set; }
+
+    /// <summary>
+    /// Gets/sets a runtime expression, if any, used to determine until when to consume messages..<para></para>
+    /// Required if <see cref="Amount"/> and <see cref="While"/> have not been set.
+    /// /// </summary>
+    [DataMember(Name = "until", Order = 4), JsonPropertyName("until"), JsonPropertyOrder(4), YamlMember(Alias = "until", Order = 4)]
+    public virtual int? Until { get; set; }
+
+}

--- a/src/ServerlessWorkflow.Sdk/Models/Calls/AsyncApiCallDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Calls/AsyncApiCallDefinition.cs
@@ -29,40 +29,51 @@ public record AsyncApiCallDefinition
     public required virtual ExternalResourceDefinition Document { get; set; }
 
     /// <summary>
-    /// Gets/sets a reference to the AsyncAPI operation to call
+    /// Gets/sets the name of the channel on which to perform the operation. The operation to perform is defined by declaring either message, in which case the channel's publish operation will be executed, or subscription, in which case the channel's subscribe operation will be executed.<para></para>
+    /// Used only in case the referenced document uses AsyncAPI v2.6.0
     /// </summary>
-    [Required]
-    [DataMember(Name = "operationRef", Order = 2), JsonPropertyName("operationRef"), JsonPropertyOrder(2), JsonInclude, YamlMember(Alias = "operationRef", Order = 2)]
-    public required virtual string OperationRef { get; set; }
+    [DataMember(Name = "channel", Order = 2), JsonPropertyName("channel"), JsonPropertyOrder(2), JsonInclude, YamlMember(Alias = "channel", Order = 2)]
+    public required virtual string? Channel { get; set; }
 
     /// <summary>
-    /// Gets/sets a reference to the server to call the specified AsyncAPI operation on. If not set, default to the first server matching the operation's channel.
+    /// Gets/sets a reference to the AsyncAPI operation to call.<para></para>
+    /// Used only in case the referenced document uses AsyncAPI v3.0.0.
     /// </summary>
-    [DataMember(Name = "server", Order = 3), JsonPropertyName("server"), JsonPropertyOrder(3), JsonInclude, YamlMember(Alias = "server", Order = 3)]
+    [DataMember(Name = "operation", Order = 3), JsonPropertyName("operation"), JsonPropertyOrder(3), JsonInclude, YamlMember(Alias = "operation", Order = 3)]
+    public required virtual string? Operation { get; set; }
+
+    /// <summary>
+    /// Gets/sets a object used to configure to the server to call the specified AsyncAPI operation on.<para></para>
+    /// If not set, default to the first server matching the operation's channel.
+    /// </summary>
+    [DataMember(Name = "server", Order = 4), JsonPropertyName("server"), JsonPropertyOrder(4), JsonInclude, YamlMember(Alias = "server", Order = 4)]
     public virtual string? Server { get; set; }
 
     /// <summary>
-    /// Gets/sets the name of the message to use. If not set, defaults to the first message defined by the operation
+    /// Gets/sets the protocol to use to select the target server.<para></para>
+    /// Ignored if <see cref="Server"/> has been set.
     /// </summary>
-    [DataMember(Name = "message", Order = 4), JsonPropertyName("message"), JsonPropertyOrder(4), JsonInclude, YamlMember(Alias = "message", Order = 4)]
-    public virtual string? Message { get; set; }
+    [DataMember(Name = "protocol", Order = 5), JsonPropertyName("protocol"), JsonPropertyOrder(5), JsonInclude, YamlMember(Alias = "protocol", Order = 5)]
+    public virtual string? Protocol { get; set; }
 
     /// <summary>
-    /// Gets/sets the name of the binding to use. If not set, defaults to the first binding defined by the operation
+    /// Gets/sets an object used to configure the message to publish using the target operation.<para></para>
+    /// Required if <see cref="Subscription"/> has not been set.
     /// </summary>
-    [DataMember(Name = "binding", Order = 5), JsonPropertyName("binding"), JsonPropertyOrder(5), JsonInclude, YamlMember(Alias = "binding", Order = 5)]
-    public virtual string? Binding { get; set; }
+    [DataMember(Name = "message", Order = 6), JsonPropertyName("message"), JsonPropertyOrder(6), JsonInclude, YamlMember(Alias = "message", Order = 6)]
+    public virtual AsyncApiMessageDefinition? Message { get; set; }
 
     /// <summary>
-    /// Gets/sets the payload to call the AsyncAPI operation with
+    /// Gets/sets an object used to configure the subscription to messages consumed using the target operation.<para></para>
+    /// Required if <see cref="Message"/> has not been set.
     /// </summary>
-    [DataMember(Name = "payload", Order = 6), JsonPropertyName("payload"), JsonPropertyOrder(6), JsonInclude, YamlMember(Alias = "payload", Order = 6)]
-    public virtual object? Payload { get; set; }
+    [DataMember(Name = "subscription", Order = 7), JsonPropertyName("subscription"), JsonPropertyOrder(7), JsonInclude, YamlMember(Alias = "subscription", Order = 7)]
+    public virtual AsyncApiSubscriptionDefinition? Subscription { get; set; }
 
     /// <summary>
     /// Gets/sets the authentication policy, if any, to use when calling the AsyncAPI operation
     /// </summary>
-    [DataMember(Name = "authentication", Order = 7), JsonPropertyName("authentication"), JsonPropertyOrder(7), JsonInclude, YamlMember(Alias = "authentication", Order = 7)]
+    [DataMember(Name = "authentication", Order = 8), JsonPropertyName("authentication"), JsonPropertyOrder(8), JsonInclude, YamlMember(Alias = "authentication", Order = 8)]
     public virtual AuthenticationPolicyDefinition? Authentication { get; set; }
 
 }

--- a/src/ServerlessWorkflow.Sdk/Models/Calls/HttpCallDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Calls/HttpCallDefinition.cs
@@ -73,4 +73,12 @@ public record HttpCallDefinition
     [DataMember(Name = "output", Order = 5), JsonPropertyName("output"), JsonPropertyOrder(5), YamlMember(Alias = "output", Order = 5)]
     public virtual string? Output { get; set; }
 
+    /// <summary>
+    /// Gets/sets a boolean indicating whether redirection status codes (300–399) should be treated as errors.<para></para>
+    /// If set to 'false', runtimes must raise an error for response status codes outside the 200–299 range.<para></para>
+    /// If set to 'true', they must raise an error for status codes outside the 200–399 range.
+    /// </summary>
+    [DataMember(Name = "redirect", Order = 6), JsonPropertyName("redirect"), JsonPropertyOrder(6), YamlMember(Alias = "redirect", Order = 6)]
+    public virtual bool Redirect { get; set; }
+
 }

--- a/src/ServerlessWorkflow.Sdk/Models/Calls/OpenApiCallDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Calls/OpenApiCallDefinition.cs
@@ -53,4 +53,12 @@ public record OpenApiCallDefinition
     [DataMember(Name = "output", Order = 6), JsonPropertyName("output"), JsonPropertyOrder(6), YamlMember(Alias = "output", Order = 6)]
     public virtual string? Output { get; set; }
 
+    /// <summary>
+    /// Gets/sets a boolean indicating whether redirection status codes (300–399) should be treated as errors.<para></para>
+    /// If set to 'false', runtimes must raise an error for response status codes outside the 200–299 range.<para></para>
+    /// If set to 'true', they must raise an error for status codes outside the 200–399 range.
+    /// </summary>
+    [DataMember(Name = "redirect", Order = 7), JsonPropertyName("redirect"), JsonPropertyOrder(7), YamlMember(Alias = "redirect", Order = 7)]
+    public virtual bool Redirect { get; set; }
+
 }

--- a/src/ServerlessWorkflow.Sdk/Models/EventConsumptionStrategyDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventConsumptionStrategyDefinition.cs
@@ -27,7 +27,8 @@ public record EventConsumptionStrategyDefinition
     public virtual EquatableList<EventFilterDefinition>? All { get; set; }
 
     /// <summary>
-    /// Gets/sets a list containing any of the events to consume, if any
+    /// Gets/sets a list containing any of the events to consume, if any.<para></para>
+    /// If empty, listens to all incoming events, and requires <see cref="Until"/> to be set.
     /// </summary>
     [DataMember(Name = "any", Order = 2), JsonPropertyName("any"), JsonPropertyOrder(2), YamlMember(Alias = "any", Order = 2)]
     public virtual EquatableList<EventFilterDefinition>? Any { get; set; }
@@ -37,5 +38,31 @@ public record EventConsumptionStrategyDefinition
     /// </summary>
     [DataMember(Name = "one", Order = 3), JsonPropertyName("one"), JsonPropertyOrder(3), YamlMember(Alias = "one", Order = 3)]
     public virtual EventFilterDefinition? One { get; set; }
+
+    /// <summary>
+    /// Gets/sets the condition or the consumption strategy that defines the events that must be consumed to stop listening
+    /// </summary>
+    [DataMember(Name = "until", Order = 4), JsonInclude, JsonPropertyName("until"), JsonPropertyOrder(4), YamlMember(Alias = "until", Order = 4)]
+    protected virtual OneOf<EventConsumptionStrategyDefinition, string>? UntilValue { get; set; }
+
+    /// <summary>
+    /// Gets/sets the consumption strategy, if any, that defines the events that must be consumed to stop listening
+    /// </summary>
+    [IgnoreDataMember, JsonIgnore, YamlIgnore]
+    public virtual EventConsumptionStrategyDefinition? Until
+    {
+        get => this.UntilValue?.T1Value;
+        set => this.UntilValue = value!;
+    }
+
+    /// <summary>
+    /// Gets/sets a runtime expression, if any, that represents the condition that must be met to stop listening
+    /// </summary>
+    [IgnoreDataMember, JsonIgnore, YamlIgnore]
+    public virtual string? UntilExpression
+    {
+        get => this.UntilValue?.T2Value;
+        set => this.UntilValue = value!;
+    }
 
 }

--- a/src/ServerlessWorkflow.Sdk/Models/EventEmissionDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/EventEmissionDefinition.cs
@@ -27,4 +27,12 @@ public record EventEmissionDefinition
     [DataMember(Name = "event", Order = 1), JsonPropertyName("event"), JsonPropertyOrder(1), YamlMember(Alias = "event", Order = 1)]
     public required virtual EventDefinition Event { get; set; }
 
+    /// <summary>
+    /// Gets/sets an additional endpoint for emitting a carbon copy of the event. 
+    /// While the runtime's default cloud event endpoint remains the primary destination, setting this property ensures that the event is also published to the specified endpoint. 
+    /// Ideally, this property is left unset so that event delivery relies solely on the runtime's configured endpoint, but when provided, the event will be sent to both endpoints concurrently.
+    /// </summary>
+    [DataMember(Name = "cc", Order = 2), JsonPropertyName("cc"), JsonPropertyOrder(2), YamlMember(Alias = "cc", Order = 2)]
+    public virtual EndpointDefinition? Cc { get; set; }
+
 }

--- a/src/ServerlessWorkflow.Sdk/Models/ProcessTypeDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/ProcessTypeDefinition.cs
@@ -53,6 +53,14 @@ public record ProcessTypeDefinition
     public virtual bool? Await { get; set; }
 
     /// <summary>
+    /// Gets/sets the output of the process.<para></para>
+    /// See <see cref="ProcessReturnType"/><para></para>
+    /// Defaults to <see cref="ProcessReturnType.Stdout"/>
+    /// </summary>
+    [DataMember(Name = "return", Order = 6), JsonPropertyName("return"), JsonPropertyOrder(6), YamlMember(Alias = "return", Order = 6)]
+    public virtual string? Return { get; set; }
+
+    /// <summary>
     /// Gets the type of the defined process tasks
     /// </summary>
     [IgnoreDataMember, JsonIgnore, YamlIgnore]

--- a/src/ServerlessWorkflow.Sdk/Models/Processes/ContainerLifetimeDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Processes/ContainerLifetimeDefinition.cs
@@ -1,0 +1,38 @@
+﻿// Copyright © 2024-Present The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ServerlessWorkflow.Sdk.Models.Processes;
+
+/// <summary>
+/// Represents an object used to configure the lifetime of a container
+/// </summary>
+[DataContract]
+public record ContainerLifetimeDefinition
+{
+
+    /// <summary>
+    /// Gets/sets the cleanup policy to use.<para></para>
+    /// See <see cref="ContainerCleanupPolicy"/><para></para>
+    /// Defaults to <see cref="ContainerCleanupPolicy.Never"/>
+    /// </summary>
+    [Required, MinLength(1)]
+    [DataMember(Name = "cleanup", Order = 1), JsonPropertyName("cleanup"), JsonPropertyOrder(1), YamlMember(Alias = "cleanup", Order = 1)]
+    public required virtual string Cleanup { get; set; }
+
+    /// <summary>
+    /// Gets/sets the duration, if any, after which to delete the container once executed.<para></para>
+    /// Required if <see cref="Cleanup"/> has been set to <see cref="ContainerCleanupPolicy.Eventually"/>, otherwise ignored.
+    /// </summary>
+    [DataMember(Name = "duration", Order = 2), JsonPropertyName("duration"), JsonPropertyOrder(2), YamlMember(Alias = "duration", Order = 2)]
+    public virtual Duration? Duration { get; set; }
+}

--- a/src/ServerlessWorkflow.Sdk/Models/Processes/ContainerProcessDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Processes/ContainerProcessDefinition.cs
@@ -52,4 +52,10 @@ public record ContainerProcessDefinition
     [DataMember(Name = "environment", Order = 5), JsonPropertyName("environment"), JsonPropertyOrder(5), YamlMember(Alias = "environment", Order = 5)]
     public virtual EquatableDictionary<string, string>? Environment { get; set; }
 
+    /// <summary>
+    /// Gets/sets an object object used to configure the container's lifetime
+    /// </summary>
+    [DataMember(Name = "lifetime", Order = 6), JsonPropertyName("lifetime"), JsonPropertyOrder(6), YamlMember(Alias = "lifetime", Order = 6)]
+    public virtual ContainerLifetimeDefinition? Lifetime { get; set; }
+
 }

--- a/src/ServerlessWorkflow.Sdk/Models/Processes/ContainerProcessDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Processes/ContainerProcessDefinition.cs
@@ -29,7 +29,7 @@ public record ContainerProcessDefinition
     public required virtual string Image { get; set; }
 
     /// <summary>
-    /// Gets/sets the name of the container image to run
+    /// Gets/sets a runtime expression, if any, used to give specific name to the container
     /// </summary>
     [DataMember(Name = "name", Order = 2), JsonPropertyName("name"), JsonPropertyOrder(2), YamlMember(Alias = "name", Order = 2)]
     public virtual string? Name { get; set; }

--- a/src/ServerlessWorkflow.Sdk/Models/Processes/ContainerProcessDefinition.cs
+++ b/src/ServerlessWorkflow.Sdk/Models/Processes/ContainerProcessDefinition.cs
@@ -26,36 +26,42 @@ public record ContainerProcessDefinition
     /// </summary>
     [Required, MinLength(1)]
     [DataMember(Name = "image", Order = 1), JsonPropertyName("image"), JsonPropertyOrder(1), YamlMember(Alias = "image", Order = 1)]
-    public required virtual string Image { get; set; } = null!;
+    public required virtual string Image { get; set; }
+
+    /// <summary>
+    /// Gets/sets the name of the container image to run
+    /// </summary>
+    [DataMember(Name = "name", Order = 2), JsonPropertyName("name"), JsonPropertyOrder(2), YamlMember(Alias = "name", Order = 2)]
+    public virtual string? Name { get; set; }
 
     /// <summary>
     /// Gets/sets the command, if any, to execute on the container
     /// </summary>
-    [DataMember(Name = "command", Order = 2), JsonPropertyName("command"), JsonPropertyOrder(2), YamlMember(Alias = "command", Order = 2)]
+    [DataMember(Name = "command", Order = 3), JsonPropertyName("command"), JsonPropertyOrder(3), YamlMember(Alias = "command", Order = 3)]
     public virtual string? Command { get; set; }
 
     /// <summary>
     /// Gets/sets a list containing the container's port mappings, if any
     /// </summary>
-    [DataMember(Name = "ports", Order = 3), JsonPropertyName("ports"), JsonPropertyOrder(3), YamlMember(Alias = "ports", Order = 3)]
+    [DataMember(Name = "ports", Order = 4), JsonPropertyName("ports"), JsonPropertyOrder(4), YamlMember(Alias = "ports", Order = 4)]
     public virtual EquatableDictionary<ushort, ushort>? Ports { get; set; }
 
     /// <summary>
     /// Gets/sets the volume mapping for the container, if any
     /// </summary>
-    [DataMember(Name = "volumes", Order = 4), JsonPropertyName("volumes"), JsonPropertyOrder(4), YamlMember(Alias = "volumes", Order = 4)]
+    [DataMember(Name = "volumes", Order = 5), JsonPropertyName("volumes"), JsonPropertyOrder(5), YamlMember(Alias = "volumes", Order = 5)]
     public virtual EquatableDictionary<string, string>? Volumes { get; set; }
 
     /// <summary>
     /// Gets/sets a key/value mapping of the environment variables, if any, to use when running the configured process
     /// </summary>
-    [DataMember(Name = "environment", Order = 5), JsonPropertyName("environment"), JsonPropertyOrder(5), YamlMember(Alias = "environment", Order = 5)]
+    [DataMember(Name = "environment", Order = 6), JsonPropertyName("environment"), JsonPropertyOrder(6), YamlMember(Alias = "environment", Order = 6)]
     public virtual EquatableDictionary<string, string>? Environment { get; set; }
 
     /// <summary>
     /// Gets/sets an object object used to configure the container's lifetime
     /// </summary>
-    [DataMember(Name = "lifetime", Order = 6), JsonPropertyName("lifetime"), JsonPropertyOrder(6), YamlMember(Alias = "lifetime", Order = 6)]
+    [DataMember(Name = "lifetime", Order = 7), JsonPropertyName("lifetime"), JsonPropertyOrder(7), YamlMember(Alias = "lifetime", Order = 7)]
     public virtual ContainerLifetimeDefinition? Lifetime { get; set; }
 
 }

--- a/src/ServerlessWorkflow.Sdk/ProcessReturnType.cs
+++ b/src/ServerlessWorkflow.Sdk/ProcessReturnType.cs
@@ -1,0 +1,56 @@
+﻿// Copyright © 2024-Present The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ServerlessWorkflow.Sdk;
+
+/// <summary>
+/// Enumerates all supported process return types
+/// </summary>
+public static class ProcessReturnType
+{
+
+    /// <summary>
+    /// Indicates that the process must return only the content of its Standard Output (STDOUT) stream
+    /// </summary>
+    public const string Stdout = "stdout";
+    /// <summary>
+    /// Indicates that the process must return only the content of its Standard Error (STDERR) stream
+    /// </summary>
+    public const string Stderr = "stderr";
+    /// <summary>
+    /// Indicates that the process must return only its exit code
+    /// </summary>
+    public const string Code = "code";
+    /// <summary>
+    /// Indicates that the process must return an object that wraps the content of its STDOUT stream, the content of its STDERR stream and its exit code
+    /// </summary>
+    public const string All = "all";
+    /// <summary>
+    /// Indicates that the process must not return anything
+    /// </summary>
+    public const string None = "none";
+
+    /// <summary>
+    /// Gets a new <see cref="IEnumerable{T}"/> containing all supported values
+    /// </summary>
+    /// <returns>A new <see cref="IEnumerable{T}"/> containing all supported values</returns>
+    public static IEnumerable<string> AsEnumerable()
+    {
+        yield return Stdout;
+        yield return Stderr;
+        yield return Code;
+        yield return All;
+        yield return None;
+    }
+
+}

--- a/src/ServerlessWorkflow.Sdk/RuntimeExpressions.cs
+++ b/src/ServerlessWorkflow.Sdk/RuntimeExpressions.cs
@@ -82,6 +82,29 @@ public static class RuntimeExpressions
         /// Gets the name of the 'error' argument, used to access the current error, if any
         /// </summary>
         public const string Error = "error";
+        /// <summary>
+        /// Gets the name of the 'authorization' argument, used to access a task's resolved authorization
+        /// </summary>
+        public const string Authorization = "authorization";
+
+        /// <summary>
+        /// Gets an <see cref="IEnumerable{T}"/> that contains all supported runtime expression arguments
+        /// </summary>
+        /// <returns>A new <see cref="IEnumerable{T}"/> that contains all supported runtime expression arguments</returns>
+        public static IEnumerable<string> AsEnumerable()
+        {
+            yield return Runtime;
+            yield return Workflow;
+            yield return Context;
+            yield return Each;
+            yield return Index;
+            yield return Output;
+            yield return Secret;
+            yield return Task;
+            yield return Input;
+            yield return Error;
+            yield return Authorization;
+        }
 
     }
 

--- a/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
+++ b/src/ServerlessWorkflow.Sdk/ServerlessWorkflow.Sdk.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.4</VersionSuffix>
+	<VersionSuffix>alpha6</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<NeutralLanguage>en</NeutralLanguage>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- [Adds a new `until` property to the `listen` task, used to configure the condition or consumption strategy that defines when to stop listening for incoming events](https://github.com/serverlessworkflow/specification/pull/997)
- [Adds a new `cc` property to the `emit` task, allowing to publish a carbon copy of the configured event to a configured endpoint](https://github.com/serverlessworkflow/specification/pull/1047) 
- [Adds a new `$authorization` runtime expression argument](https://github.com/serverlessworkflow/specification/pull/1048)
- [Adds a new `lifetime` property to the `container` process, used to configure the lifetime of the defined container](https://github.com/serverlessworkflow/specification/pull/1049)
- [Adds a new `return` property to the `run` task, allowing to define the return of the configured process](https://github.com/serverlessworkflow/specification/pull/1052)
- [Refactors the `asyncapi` call, to allow proper integration of both v2.6.0 and v3.0.0 of the AsyncAPI specification](https://github.com/serverlessworkflow/specification/pull/1053)
- [Adds a new `redirect` property to both `http` and `openapi` calls, allowing to define whether or not to consider redirections as errors](https://github.com/serverlessworkflow/specification/pull/1057)